### PR TITLE
Generators

### DIFF
--- a/Generator/Commands/RouteGenerator.php
+++ b/Generator/Commands/RouteGenerator.php
@@ -55,7 +55,7 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
      *
      * @var  string
      */
-    protected $pathStructure = '{container-name}/UI/API/Routes/*';
+    protected $pathStructure = '{container-name}/UI/{user-interface}/Routes/*';
 
     /**
      * The structure of the file name.
@@ -78,6 +78,7 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
      * @var  array
      */
     public $inputs = [
+        ['ui', null, InputOption::VALUE_OPTIONAL, 'The user-interface to generate the Controller for.'],
         ['operation', null, InputOption::VALUE_OPTIONAL, 'The operation from the Controller to be called (e.g., index)'],
         ['doctype', null, InputOption::VALUE_OPTIONAL, 'The type of the endpoint (private, public)'],
         ['docversion', null, InputOption::VALUE_OPTIONAL, 'The version of the endpoint (1, 2, ...)'],
@@ -90,6 +91,7 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
      */
     public function getUserInputs()
     {
+        $ui = Str::lower($this->checkParameterOrChoice('ui', 'Select the UI for the controller', ['API', 'WEB']));
         $version = $this->checkParameterOrAsk('docversion', 'Enter the endpoint version (integer)', self::DEFAULT_VERSION);
         $doctype = $this->checkParameterOrChoice('doctype', 'Select the type for this endpoint', ['private', 'public']);
         $operation = $this->checkParameterOrAsk('operation', 'Enter the name of the controller function that needs to be invoked when calling this endpoint');
@@ -100,11 +102,13 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
 
         return [
             'path-parameters' => [
-                'container-name' => $this->containerName,
+                'container-name'    => $this->containerName,
+                'user-interface'    => Str::upper($ui),
             ],
             'stub-parameters' => [
                 'container-name'            => $this->containerName,
                 'operation'                 => $operation,
+                'user-interface'            => Str::upper($ui),
                 'endpoint-url'              => $url,
                 'versioned-endpoint-url'    => '/v' . $version . '/' . $url,
                 'endpoint-version'          => $version,

--- a/Generator/Stubs/repository.stub
+++ b/Generator/Stubs/repository.stub
@@ -9,6 +9,11 @@ use App\Ship\Parents\Repositories\Repository;
  */
 class {{class-name}} extends Repository
 {
+
+    // The Container Name.
+	// Must be set when the model has a different name than the container
+    protected $container = '{{container-name}}';
+
     /**
      * @var array
      */

--- a/Generator/Stubs/route.stub
+++ b/Generator/Stubs/route.stub
@@ -20,6 +20,7 @@
  */
 
 $router->{{http-verb}}('{{endpoint-url}}', [
+    'as' => '{{user-interface}}_{{container-name}}_{{operation}}',
     'uses'  => 'Controller@{{operation}}',
     'middleware' => [
       'auth:api',


### PR DESCRIPTION
Adds a few more details to the generators.
1) the `route` generator now has an input to define which `ui` to be used (API / WEB).
2) the `route` generator now generates an `as` name for the Route. This name is as defined as follows: `UI_CONTAINER_OPERATION`. This results, for example, in: `API_User_listAllUsers`.
3) Added the `$container` property to the `Repository` stub. The value is automatically set to the `container-name`, so it does not change anything by default. However, if you have a model that has not the same name as the Container, this would create a "valid" Model / Repository / Container configuration. This specifically tackles [this issue here](https://github.com/apiato/apiato/issues/216)

Cheers!