### PR TITLE
[Feature] Load "Custom Stubs"

### DIFF
--- a/Generator/Commands/ConfigurationGenerator.php
+++ b/Generator/Commands/ConfigurationGenerator.php
@@ -92,6 +92,6 @@ class ConfigurationGenerator extends GeneratorCommand implements ComponentsGener
      */
     public function getDefaultFileName()
     {
-        return 'container.' . $this->containerName;
+        return 'container.' . Str::lower($this->containerName);
     }
 }

--- a/Generator/GeneratorCommand.php
+++ b/Generator/GeneratorCommand.php
@@ -38,6 +38,11 @@ abstract class GeneratorCommand extends Command
     CONST STUB_PATH = 'Stubs/*';
 
     /**
+     * Relative path for the custom stubs (relative to the app/Ship directory!
+     */
+    CONST CUSTOM_STUB_PATH = 'Generators/CustomStubs/*';
+
+    /**
      * Containers main folder
      *
      * @var string
@@ -122,7 +127,7 @@ abstract class GeneratorCommand extends Command
         $this->filePath = $this->getFilePath($this->parsePathStructure($this->pathStructure, $this->userData['path-parameters']));
 
         // prepare stub content
-        $this->stubContent = $this->fileSystem->get($this->getStubFile());
+        $this->stubContent = $this->getStubContent();
         $this->renderedStubContent = $this->parseStubContent($this->stubContent, $this->userData['stub-parameters']);
 
         $this->generateFile($this->filePath, $this->renderedStubContent);
@@ -165,11 +170,22 @@ abstract class GeneratorCommand extends Command
     /**
      * @return  mixed
      */
-    protected function getStubFile()
+    protected function getStubContent()
     {
-        $path = __DIR__ . '/' . self::STUB_PATH;
+        // check if there is a custom file that overrides the default stubs
+        $path = app_path() . '/Ship/' . self::CUSTOM_STUB_PATH;
+        $file = str_replace('*', $this->stubName, $path);
 
-        return str_replace('*', $this->stubName, $path);
+        // check if the custom file exists
+        if (! $this->fileSystem->exists($file)) {
+            // it does not exist - so take the default file!
+            $path = __DIR__ . '/' . self::STUB_PATH;
+            $file = str_replace('*', $this->stubName, $path);
+        }
+
+        // now load the stub
+        $stub = $this->fileSystem->get($file);
+        return $stub;
     }
 
     /**


### PR DESCRIPTION
This PR allows developers to load `custom stubs` for the generators instead of using the default ones.

Stubs must be placed in `/app/Ship/Generators/CustomStubs/*`

See the other PR in `apiato/apiato` as well...