### PR TITLE
Route stub auth middleware wrong for WEB UI

### DIFF
--- a/Generator/Commands/RouteGenerator.php
+++ b/Generator/Commands/RouteGenerator.php
@@ -106,6 +106,7 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
                 'http-verb' => Str::lower($verb),
                 'doc-http-verb' => Str::upper($verb),
                 'route-name' => $routename,
+                'auth-middleware' => Str::lower($ui),
             ],
             'file-parameters' => [
                 'endpoint-name' => $this->fileName,

--- a/Generator/Stubs/route.stub
+++ b/Generator/Stubs/route.stub
@@ -23,6 +23,6 @@ $router->{{http-verb}}('{{endpoint-url}}', [
     'as' => '{{route-name}}',
     'uses'  => 'Controller@{{operation}}',
     'middleware' => [
-      'auth:api',
+      'auth:{{auth-middleware}}',
     ],
 ]);


### PR DESCRIPTION
Hello,

When generating a route for WEB UI it always adds auth:api middleware which forces you to change it to auth:web if you are generating the route for WEB UI.