### PR TITLE
WEB UI container generators update

### DIFF
--- a/Generator/Commands/ContainerGenerator.php
+++ b/Generator/Commands/ContainerGenerator.php
@@ -192,6 +192,82 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
                 'task'      => 'Delete' . $model . 'Task',
             ],
         ];
+
+        if ($ui == 'web') {
+            $routes = [
+                [
+                    'stub'      => 'GetAll',
+                    'name'      => 'GetAll' . $models,
+                    'operation' => 'index',
+                    'verb'      => 'GET',
+                    'url'       => $url,
+                    'action'    => 'GetAll' . $models . 'Action',
+                    'request'   => 'GetAll' . $models . 'Request',
+                    'task'      => 'GetAll' . $models . 'Task',
+                ],
+                [
+                    'stub'      => 'GetOne',
+                    'name'      => 'Get' . $model . 'ById',
+                    'operation' => 'show',
+                    'verb'      => 'GET',
+                    'url'       => $url . '/{id}',
+                    'action'    => 'Get' . $model . 'ById' . 'Action',
+                    'request'   => 'Get' . $model . 'ById' . 'Request',
+                    'task'      => 'Get' . $model . 'ById' . 'Task',
+                ],
+                [
+                    'stub'      => null,
+                    'name'      => 'Create' . $model,
+                    'operation' => 'create',
+                    'verb'      => 'GET',
+                    'url'       => $url . '/create',
+                    'action'    => null,
+                    'request'   => 'Create' . $model . 'Request',
+                    'task'      => null,
+                ],
+                [
+                    'stub'      => 'Create',
+                    'name'      => 'Store' . $model,
+                    'operation' => 'store',
+                    'verb'      => 'POST',
+                    'url'       => $url . '/store',
+                    'action'    => 'Create' . $model . 'Action',
+                    'request'   => 'Store' . $model . 'Request',
+                    'task'      => 'Create' . $model . 'Task',
+                ],
+                [
+                    'stub'      => null,
+                    'name'      => 'Edit' . $model,
+                    'operation' => 'edit',
+                    'verb'      => 'GET',
+                    'url'       => $url . '/{id}/edit',
+                    'action'    => null,
+                    'request'   => 'Edit' . $model . 'Request',
+                    'task'      => null,
+                ],
+                [
+                    'stub'      => 'Update',
+                    'name'      => 'Update' . $model,
+                    'operation' => 'update',
+                    'verb'      => 'PATCH',
+                    'url'       => $url . '/{id}',
+                    'action'    => 'Update' . $model . 'Action',
+                    'request'   => 'Update' . $model . 'Request',
+                    'task'      => 'Update' . $model . 'Task',
+                ],
+                [
+                    'stub'      => 'Delete',
+                    'name'      => 'Delete' . $model,
+                    'operation' => 'delete',
+                    'verb'      => 'DELETE',
+                    'url'       => $url . '/{id}',
+                    'action'    => 'Delete' . $model . 'Action',
+                    'request'   => 'Delete' . $model . 'Request',
+                    'task'      => 'Delete' . $model . 'Task',
+                ],
+            ];
+        }
+
         foreach ($routes as $route)
         {
             Artisan::call('apiato:generate:route', [
@@ -211,19 +287,23 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
                 '--ui'          => $ui,
             ]);
 
-            Artisan::call('apiato:generate:action', [
-                '--container'   => $containerName,
-                '--file'        => $route['action'],
-                '--model'       => $model,
-                '--stub'        => $route['stub'],
-            ]);
+            if ($route['action'] != null || $route['stub'] != null) {
+                Artisan::call('apiato:generate:action', [
+                    '--container' => $containerName,
+                    '--file' => $route['action'],
+                    '--model' => $model,
+                    '--stub' => $route['stub'],
+                ]);
+            }
 
-            Artisan::call('apiato:generate:task', [
-                '--container'   => $containerName,
-                '--file'        => $route['task'],
-                '--model'       => $model,
-                '--stub'        => $route['stub'],
-            ]);
+            if ($route['task'] != null || $route['stub'] != null) {
+                Artisan::call('apiato:generate:task', [
+                    '--container' => $containerName,
+                    '--file' => $route['task'],
+                    '--model' => $model,
+                    '--stub' => $route['stub'],
+                ]);
+            }
         }
 
         // finally generate the controller

--- a/Generator/Commands/ControllerGenerator.php
+++ b/Generator/Commands/ControllerGenerator.php
@@ -4,16 +4,17 @@ namespace Apiato\Core\Generator\Commands;
 
 use Apiato\Core\Generator\GeneratorCommand;
 use Apiato\Core\Generator\Interfaces\ComponentsGenerator;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Pluralizer;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 /**
- * Class ControllerGenerator
+ * Class ContainerComposerGenerator
  *
- * @author  Johannes Schobel  <johannes.schobel@googlemail.com>
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
  */
-class ControllerGenerator extends GeneratorCommand implements ComponentsGenerator
+class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
 {
 
     /**
@@ -21,28 +22,28 @@ class ControllerGenerator extends GeneratorCommand implements ComponentsGenerato
      *
      * @var string
      */
-    protected $name = 'apiato:generate:controller';
+    protected $name = 'apiato:generate:container';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Create a controller for a container';
+    protected $description = 'Create a Container for apiato from scratch';
 
     /**
      * The type of class being generated.
      *
      * @var string
      */
-    protected $fileType = 'Controller';
+    protected $fileType = 'Container';
 
     /**
      * The structure of the file path.
      *
      * @var  string
      */
-    protected $pathStructure = '{container-name}/UI/{user-interface}/Controllers/*';
+    protected $pathStructure = '{container-name}/*';
 
     /**
      * The structure of the file name.
@@ -56,58 +57,273 @@ class ControllerGenerator extends GeneratorCommand implements ComponentsGenerato
      *
      * @var  string
      */
-    protected $stubName = 'controllers/generic.stub';
+    protected $stubName = 'composer.stub';
 
     /**
-     * The options which can be passed to the command. All options are optional. You do not need to pass the
-     * "--container" and "--file" options, as they are globally handled. Just use the options which are specific to
-     * this generator.
+     * User required/optional inputs expected to be passed while calling the command.
+     * This is a replacement of the `getArguments` function "which reads whenever it's called".
      *
      * @var  array
      */
     public $inputs = [
         ['ui', null, InputOption::VALUE_OPTIONAL, 'The user-interface to generate the Controller for.'],
-        ['stub', null, InputOption::VALUE_OPTIONAL, 'The stub file to load for this generator.'],
+        ['docversion', null, InputOption::VALUE_OPTIONAL, 'The version of all endpoints to be generated (1, 2, ...)'],
+        ['doctype', null, InputOption::VALUE_OPTIONAL, 'The type of all endpoints to be generated (private, public)'],
+        ['url', null, InputOption::VALUE_OPTIONAL, 'The base URI of all endpoints (/stores, /cars, ...)'],
     ];
 
     /**
-     * @return  array
+     * urn mixed|void
      */
     public function getUserInputs()
     {
-        $ui = Str::lower($this->checkParameterOrChoice('ui', 'Select the UI for the controller', ['API', 'WEB']));
+        $ui = Str::lower($this->checkParameterOrChoice('ui', 'Select the UI for this container', ['API', 'WEB'], 0));
 
-        $stub = Str::lower($this->checkParameterOrChoice(
-            'stub',
-            'Select the Stub you want to load',
-            ['Generic', 'CRUD.API', 'CRUD.WEB'],
-            0)
-        );
+        // containername as inputted and lower
+        $containerName = $this->containerName;
+        $_containerName = Str::lower($this->containerName);
 
-        // load a new stub-file based on the users choice
-        $this->stubName = 'controllers/' . $stub . '.stub';
-
-        $basecontroller = Str::ucfirst($ui) . 'Controller';
-
+        // name of the model (singular and plural)
         $model = $this->containerName;
-        $entity = Str::lower($model);
-        $entities = Pluralizer::plural($entity);
+        $models = Pluralizer::plural($model);
 
+        // create the configuration file
+        $this->printInfoMessage('Generating Configuration File');
+        Artisan::call('apiato:generate:configuration', [
+            '--container'   => $containerName,
+            '--file'        => $_containerName,
+        ]);
+
+        // create the MainServiceProvider for the container
+        $this->printInfoMessage('Generating MainServiceProvider');
+        Artisan::call('apiato:generate:serviceprovider', [
+            '--container'   => $containerName,
+            '--file'        => 'MainServiceProvider',
+            '--stub'        => 'mainserviceprovider',
+        ]);
+
+        // create the model and repository for this container
+        $this->printInfoMessage('Generating Model and Repository');
+        Artisan::call('apiato:generate:model', [
+            '--container'   => $containerName,
+            '--file'        => $model,
+            '--repository'  => true,
+        ]);
+
+        // create the migration file for the model
+        $this->printInfoMessage('Generating a basic Migration file');
+        Artisan::call('apiato:generate:migration', [
+            '--container'   => $containerName,
+            '--file'        => 'create_' . Str::lower($_containerName) . '_tables',
+            '--tablename'   => $models,
+        ]);
+
+        // create a transformer for the model
+        $this->printInfoMessage('Generating Transformer for the Model');
+        Artisan::call('apiato:generate:transformer', [
+            '--container'   => $containerName,
+            '--file'        => $containerName . 'Transformer',
+            '--model'       => $model,
+            '--full'        => 'no',
+        ]);
+
+        // create the default routes for this container
+        $this->printInfoMessage('Generating Default Routes');
+        $version = $this->checkParameterOrAsk('docversion', 'Enter the version for *all* endpoints (integer)', 1);
+        $doctype = $this->checkParameterOrChoice('doctype', 'Select the type for *all* endpoints', ['private', 'public'], 0);
+
+        // get the URI and remove the first trailing slash
+        $url = Str::lower($this->checkParameterOrAsk('url', 'Enter the base URI for all endpoints (foo/bar)', Str::lower($models)));
+        $url = ltrim($url, '/');
+
+        $this->printInfoMessage('Creating Requests for Routes');
+        $this->printInfoMessage('Generating Default Actions');
+        $this->printInfoMessage('Generating Default Tasks');
+
+        $routes = [
+            [
+                'stub'      => 'GetAll',
+                'name'      => 'GetAll' . $models,
+                'operation' => 'getAll' . $models,
+                'verb'      => 'GET',
+                'url'       => $url,
+                'action'    => 'GetAll' . $models . 'Action',
+                'request'   => 'GetAll' . $models . 'Request',
+                'task'      => 'GetAll' . $models . 'Task',
+            ],
+            [
+                'stub'      => 'GetOne',
+                'name'      => 'Get' . $model . 'ById',
+                'operation' => 'get' . $model . 'ById',
+                'verb'      => 'GET',
+                'url'       => $url . '/{id}',
+                'action'    => 'Get' . $model . 'ById' . 'Action',
+                'request'   => 'Get' . $model . 'ById' . 'Request',
+                'task'      => 'Get' . $model . 'ById' . 'Task',
+            ],
+            [
+                'stub'      => 'Create',
+                'name'      => 'Create' . $model,
+                'operation' => 'create' . $model,
+                'verb'      => 'POST',
+                'url'       => $url,
+                'action'    => 'Create' . $model . 'Action',
+                'request'   => 'Create' . $model . 'Request',
+                'task'      => 'Create' . $model . 'Task',
+            ],
+            [
+                'stub'      => 'Update',
+                'name'      => 'Update' . $model,
+                'operation' => 'update' . $model,
+                'verb'      => 'PATCH',
+                'url'       => $url . '/{id}',
+                'action'    => 'Update' . $model . 'Action',
+                'request'   => 'Update' . $model . 'Request',
+                'task'      => 'Update' . $model . 'Task',
+            ],
+            [
+                'stub'      => 'Delete',
+                'name'      => 'Delete' . $model,
+                'operation' => 'delete' . $model,
+                'verb'      => 'DELETE',
+                'url'       => $url . '/{id}',
+                'action'    => 'Delete' . $model . 'Action',
+                'request'   => 'Delete' . $model . 'Request',
+                'task'      => 'Delete' . $model . 'Task',
+            ],
+        ];
+
+        if ($ui == 'web') {
+            $routes = [
+                [
+                    'stub'      => 'GetAll',
+                    'name'      => 'GetAll' . $models,
+                    'operation' => 'index',
+                    'verb'      => 'GET',
+                    'url'       => $url,
+                    'action'    => 'GetAll' . $models . 'Action',
+                    'request'   => 'GetAll' . $models . 'Request',
+                    'task'      => 'GetAll' . $models . 'Task',
+                ],
+                [
+                    'stub'      => 'GetOne',
+                    'name'      => 'Get' . $model . 'ById',
+                    'operation' => 'show',
+                    'verb'      => 'GET',
+                    'url'       => $url . '/{id}',
+                    'action'    => 'Get' . $model . 'ById' . 'Action',
+                    'request'   => 'Get' . $model . 'ById' . 'Request',
+                    'task'      => 'Get' . $model . 'ById' . 'Task',
+                ],
+                [
+                    'stub'      => null,
+                    'name'      => 'Create' . $model,
+                    'operation' => 'create',
+                    'verb'      => 'GET',
+                    'url'       => $url . '/create',
+                    'action'    => null,
+                    'request'   => 'Create' . $model . 'Request',
+                    'task'      => null,
+                ],
+                [
+                    'stub'      => 'Create',
+                    'name'      => 'Store' . $model,
+                    'operation' => 'store',
+                    'verb'      => 'POST',
+                    'url'       => $url . '/store',
+                    'action'    => 'Create' . $model . 'Action',
+                    'request'   => 'Store' . $model . 'Request',
+                    'task'      => 'Create' . $model . 'Task',
+                ],
+                [
+                    'stub'      => null,
+                    'name'      => 'Edit' . $model,
+                    'operation' => 'edit',
+                    'verb'      => 'GET',
+                    'url'       => $url . '/{id}/edit',
+                    'action'    => null,
+                    'request'   => 'Edit' . $model . 'Request',
+                    'task'      => null,
+                ],
+                [
+                    'stub'      => 'Update',
+                    'name'      => 'Update' . $model,
+                    'operation' => 'update',
+                    'verb'      => 'PATCH',
+                    'url'       => $url . '/{id}',
+                    'action'    => 'Update' . $model . 'Action',
+                    'request'   => 'Update' . $model . 'Request',
+                    'task'      => 'Update' . $model . 'Task',
+                ],
+                [
+                    'stub'      => 'Delete',
+                    'name'      => 'Delete' . $model,
+                    'operation' => 'delete',
+                    'verb'      => 'DELETE',
+                    'url'       => $url . '/{id}',
+                    'action'    => 'Delete' . $model . 'Action',
+                    'request'   => 'Delete' . $model . 'Request',
+                    'task'      => 'Delete' . $model . 'Task',
+                ],
+            ];
+        }
+
+        foreach ($routes as $route)
+        {
+            Artisan::call('apiato:generate:route', [
+                '--container'   => $containerName,
+                '--file'        => $route['name'],
+                '--ui'          => $ui,
+                '--operation'   => $route['operation'],
+                '--doctype'     => $doctype,
+                '--docversion'  => $version,
+                '--url'         => $route['url'],
+                '--verb'        => $route['verb'],
+            ]);
+
+            Artisan::call('apiato:generate:request', [
+                '--container'   => $containerName,
+                '--file'        => $route['request'],
+                '--ui'          => $ui,
+            ]);
+
+            if ($route['action'] != null || $route['stub'] != null) {
+                Artisan::call('apiato:generate:action', [
+                    '--container' => $containerName,
+                    '--file' => $route['action'],
+                    '--model' => $model,
+                    '--stub' => $route['stub'],
+                ]);
+            }
+
+            if ($route['task'] != null || $route['stub'] != null) {
+                Artisan::call('apiato:generate:task', [
+                    '--container' => $containerName,
+                    '--file' => $route['task'],
+                    '--model' => $model,
+                    '--stub' => $route['stub'],
+                ]);
+            }
+        }
+
+        // finally generate the controller
+        $this->printInfoMessage('Generating Controller to wire everything together');
+        Artisan::call('apiato:generate:controller', [
+            '--container'   => $containerName,
+            '--file'        => 'Controller',
+            '--ui'          => $ui,
+            '--stub'        => 'crud.' . $ui,
+        ]);
+
+        $this->printInfoMessage('Generating Composer File');
         return [
             'path-parameters' => [
-                'container-name' => $this->containerName,
-                'user-interface' => Str::upper($ui),
+                'container-name' => $containerName,
             ],
             'stub-parameters' => [
-                '_container-name' => Str::lower($this->containerName),
-                'container-name' => $this->containerName,
+                '_container-name' => $_containerName,
+                'container-name' => $containerName,
                 'class-name' => $this->fileName,
-                'user-interface' => Str::upper($ui),
-                'base-controller' => $basecontroller,
-
-                'model' => $model,
-                'entity' => $entity,
-                'entities' => $entities,
             ],
             'file-parameters' => [
                 'file-name' => $this->fileName,
@@ -115,9 +331,19 @@ class ControllerGenerator extends GeneratorCommand implements ComponentsGenerato
         ];
     }
 
+    /**
+     * Get the default file name for this component to be generated
+     *
+     * @return string
+     */
     public function getDefaultFileName()
     {
-        return 'Controller';
+        return 'composer';
+    }
+
+    public function getDefaultFileExtension()
+    {
+        return '.json';
     }
 
 }

--- a/Generator/Commands/RouteGenerator.php
+++ b/Generator/Commands/RouteGenerator.php
@@ -94,6 +94,14 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
             $this->stubName = 'routes/api.stub';
         }
 
+        if ($ui == 'web') {
+            if (str_contains($url, '{id}')) {
+                $this->stubName = 'routes/web.id.stub';
+            } else {
+                $this->stubName = 'routes/generic.stub';
+            }
+        }
+
         return [
             'path-parameters' => [
                 'container-name' => $this->containerName,

--- a/Generator/Commands/RouteGenerator.php
+++ b/Generator/Commands/RouteGenerator.php
@@ -37,7 +37,7 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
     protected $fileType = 'Route';
 
     /**
-     * THe structure of the file path.
+     * The structure of the file path.
      *
      * @var  string
      */
@@ -55,7 +55,7 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
      *
      * @var  string
      */
-    protected $stubName = 'route.stub';
+    protected $stubName = 'routes/generic.stub';
 
     /**
      * User required/optional inputs expected to be passed while calling the command.
@@ -89,6 +89,10 @@ class RouteGenerator extends GeneratorCommand implements ComponentsGenerator
         $docurl = preg_replace('~\{(.+?)\}~', ':$1', $url);
 
         $routename = Str::lower($ui . '_' . $this->containerName . '_' . Str::snake($operation));
+
+        if ($ui == 'api') {
+            $this->stubName = 'routes/api.stub';
+        }
 
         return [
             'path-parameters' => [

--- a/Generator/Stubs/controllers/crud.web.stub
+++ b/Generator/Stubs/controllers/crud.web.stub
@@ -2,57 +2,100 @@
 
 namespace App\Containers\{{container-name}}\UI\{{user-interface}}\Controllers;
 
+use App\Containers\{{container-name}}\Actions\Create{{model}}Action;
+use App\Containers\{{container-name}}\Actions\Delete{{model}}Action;
+use App\Containers\{{container-name}}\Actions\GetAll{{model}}sAction;
+use App\Containers\{{container-name}}\Actions\Get{{model}}ByIdAction;
+use App\Containers\{{container-name}}\Actions\Update{{model}}Action;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Create{{model}}Request;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Store{{model}}Request;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Delete{{model}}Request;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\GetAll{{model}}sRequest;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Get{{model}}ByIdRequest;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Edit{{model}}Request;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Update{{model}}Request;
 use App\Ship\Parents\Controllers\WebController;
 use App\Ship\Parents\Requests\Request;
 
+/**
+ * Class {{class-name}}
+ *
+ * @package App\Containers\{{container-name}}\UI\{{user-interface}}\Controllers
+ */
 class {{class-name}} extends WebController
 {
     /**
      * Show all entities
+     *
+     * @param GetAll{{model}}sRequest $request
      */
-    public function index(Request $request) {
+    public function index(GetAll{{model}}sRequest $request) {
+        ${{entities}} = $this->call(GetAll{{model}}sAction::class, [$request]);
 
+        // ..
     }
 
     /**
      * Show one entity
+     *
+     * @param Get{{model}}ByIdRequest $request
      */
-    public function show(Request $request) {
+    public function show(Get{{model}}ByIdRequest $request) {
+        ${{entity}} = $this->call(Get{{model}}ByIdAction::class, [$request]);
 
+        // ..
     }
 
     /**
      * Create entity (show UI)
+     *
+     * @param Create{{model}}Request $request
      */
-    public function create(Request $request) {
+    public function create(Create{{model}}Request $request) {
 
     }
 
     /**
      * Add a new entity
+     *
+     * @param Store{{model}}Request $request
      */
-    public function store(Request $request) {
+    public function store(Store{{model}}Request $request) {
+        ${{entity}} = $this->call(Create{{model}}Action::class, [$request]);
 
+        // ..
     }
 
     /**
      * Edit entity (show UI)
+     *
+     * @param Edit{{model}}Request $request
      */
-    public function edit(Request $request) {
+    public function edit(Edit{{model}}Request $request) {
+        ${{entity}} = $this->call(Get{{model}}ByIdAction::class, [$request]);
 
+        // ..
     }
 
     /**
      * Update a given entity
+     *
+     * @param Update{{model}}Request $request
      */
-    public function update(Request $request) {
+    public function update(Update{{model}}Request $request) {
+        ${{entity}} = $this->call(Update{{model}}Action::class, [$request]);
 
+        // ..
     }
 
     /**
      * Delete a given entity
+     *
+     * @param Delete{{model}}Request $request
      */
-    public function delete(Request $request) {
+    public function delete(Delete{{model}}Request $request) {
+         $result = $this->call(Delete{{model}}Action::class, [$request]);
 
+         // ..
     }
 }

--- a/Generator/Stubs/controllers/crud.web.stub
+++ b/Generator/Stubs/controllers/crud.web.stub
@@ -4,18 +4,17 @@ namespace App\Containers\{{container-name}}\UI\{{user-interface}}\Controllers;
 
 use App\Containers\{{container-name}}\Actions\Create{{model}}Action;
 use App\Containers\{{container-name}}\Actions\Delete{{model}}Action;
-use App\Containers\{{container-name}}\Actions\GetAll{{model}}sAction;
+use App\Containers\{{container-name}}\Actions\GetAll{{models}}Action;
 use App\Containers\{{container-name}}\Actions\Get{{model}}ByIdAction;
 use App\Containers\{{container-name}}\Actions\Update{{model}}Action;
 use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Create{{model}}Request;
 use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Store{{model}}Request;
 use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Delete{{model}}Request;
-use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\GetAll{{model}}sRequest;
+use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\GetAll{{models}}Request;
 use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Get{{model}}ByIdRequest;
 use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Edit{{model}}Request;
 use App\Containers\{{container-name}}\UI\{{user-interface}}\Requests\Update{{model}}Request;
 use App\Ship\Parents\Controllers\WebController;
-use App\Ship\Parents\Requests\Request;
 
 /**
  * Class {{class-name}}
@@ -27,10 +26,10 @@ class {{class-name}} extends WebController
     /**
      * Show all entities
      *
-     * @param GetAll{{model}}sRequest $request
+     * @param GetAll{{models}}Request $request
      */
-    public function index(GetAll{{model}}sRequest $request) {
-        ${{entities}} = $this->call(GetAll{{model}}sAction::class, [$request]);
+    public function index(GetAll{{models}}Request $request) {
+        ${{entities}} = $this->call(GetAll{{models}}Action::class, [$request]);
 
         // ..
     }

--- a/Generator/Stubs/routes/api.stub
+++ b/Generator/Stubs/routes/api.stub
@@ -19,6 +19,7 @@
 }
  */
 
+/** @var Route $router */
 $router->{{http-verb}}('{{endpoint-url}}', [
     'as' => '{{route-name}}',
     'uses'  => 'Controller@{{operation}}',

--- a/Generator/Stubs/routes/api.stub
+++ b/Generator/Stubs/routes/api.stub
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @apiGroup           {{container-name}}
+ * @apiName            {{operation}}
+ *
+ * @api                {{{doc-http-verb}}} {{doc-endpoint-url}} Endpoint title here..
+ * @apiDescription     Endpoint description here..
+ *
+ * @apiVersion         {{endpoint-version}}.0.0
+ * @apiPermission      none
+ *
+ * @apiParam           {String}  parameters here..
+ *
+ * @apiSuccessExample  {json}  Success-Response:
+ * HTTP/1.1 200 OK
+{
+  // Insert the response of the request here...
+}
+ */
+
+$router->{{http-verb}}('{{endpoint-url}}', [
+    'as' => '{{route-name}}',
+    'uses'  => 'Controller@{{operation}}',
+    'middleware' => [
+      'auth:{{auth-middleware}}',
+    ],
+]);

--- a/Generator/Stubs/routes/generic.stub
+++ b/Generator/Stubs/routes/generic.stub
@@ -1,5 +1,6 @@
 <?php
 
+/** @var Route $router */
 $router->{{http-verb}}('{{endpoint-url}}', [
     'as' => '{{route-name}}',
     'uses'  => 'Controller@{{operation}}',

--- a/Generator/Stubs/routes/generic.stub
+++ b/Generator/Stubs/routes/generic.stub
@@ -1,0 +1,9 @@
+<?php
+
+$router->{{http-verb}}('{{endpoint-url}}', [
+    'as' => '{{route-name}}',
+    'uses'  => 'Controller@{{operation}}',
+    'middleware' => [
+      'auth:{{auth-middleware}}',
+    ],
+]);

--- a/Generator/Stubs/routes/web.id.stub
+++ b/Generator/Stubs/routes/web.id.stub
@@ -1,0 +1,10 @@
+<?php
+
+/** @var Route $router */
+$router->{{http-verb}}('{{endpoint-url}}', [
+    'as' => '{{route-name}}',
+    'uses'  => 'Controller@{{operation}}',
+    'middleware' => [
+      'auth:{{auth-middleware}}',
+    ],
+])->where('id', '[0-9]+');


### PR DESCRIPTION
Hello,

I am using the WEB UI pretty a lot with apiato and now with the container generator it speeds up the process a lot but I see that it is not very often used and updated so I decided to help others and myself.

Changes made:
- Generate correct CRUD routes, requests and actions, phpdoc
- Allow to use `null` in stub, action, task( Ėroutes if the route does not require a new action/task (like WEB UI create/edit methods)
- Generate route based on UI: if the UI is api then generate api route with docs. If not use generic route stub
- Controller generate to pass plural model name

Known issues:

- [x] Url **resource/{id}** conflicts with **resource/create**
Solution: **->where('id', '[0-9]+');** at the end of the route

I have tried to make the container generator as clean as possible. I am open to suggestions how to refactor it to make it look better if someone thinks this is too ugly to commit.
