### PR TITLE
Hash ID's small bug fix

### DIFF
--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -101,6 +101,9 @@ trait HashIdTrait
 
         // is the current field an array?! we need to process it like crazy
         if($field == '*') {
+            //make sure field value is an array
+            $data = is_array($data) ? $data : [$data];
+
             // process each field of the array (and go down one level!)
             $fields = $data;
             foreach($fields as $key => $value) {


### PR DESCRIPTION
This fix prevent to occur error mentioned here [Invalid argument supplied for foreach() #250](https://github.com/apiato/apiato/issues/250)
Error happens when pass single value to field marked as an array (e.g. `field.* => 1`)