### PR TITLE
fix WEB UI Exceptions

### DIFF
--- a/Exceptions/Handlers/ExceptionsHandler.php
+++ b/Exceptions/Handlers/ExceptionsHandler.php
@@ -2,7 +2,10 @@
 
 namespace Apiato\Core\Exceptions\Handlers;
 
+use Exception;
+use Illuminate\Support\Facades\Config;
 use Optimus\Heimdal\ExceptionHandler as HeimdalExceptionHandler;
+use Illuminate\Foundation\Exceptions\Handler as LaravelExceptionHandler;
 
 /**
  * Class ExceptionsHandler
@@ -11,5 +14,15 @@ use Optimus\Heimdal\ExceptionHandler as HeimdalExceptionHandler;
  */
 class ExceptionsHandler extends HeimdalExceptionHandler
 {
+    public function render($request, Exception $e)
+    {
+        // if the user expects json or the API forces the user to send it
+        if (($request->expectsJson()) || (Config::get('apiato.requests.force-accept-header'))) {
+            // return the error as json
+            return parent::render($request, $e);
+        }
 
+        // neither the user nor the application wants json
+        return LaravelExceptionHandler::render($request, $e);
+    }
 }


### PR DESCRIPTION
This PR fixes the `WEB UI Exception` problem.. 

Thing is, that somewhere in history this "dispatcher" to trigger specific renderer was removed..
Logic is as follows:
If the User requests `application/json` **OR** the application forces the User to use it (the config-flag `apiato.requests.force-accept-header` is set to `true`) --> use the `JSON Exception`

If this does not match, use the `WEB Exception`

Screenshot:
![2017-10-18 08_49_24-page not found](https://user-images.githubusercontent.com/9431350/31704442-b03e68de-b3e1-11e7-8379-3b70e0196fbe.png)
