### PR TITLE
fix apiato:generate:mail folder issue

### DIFF
--- a/Generator/Commands/MailGenerator.php
+++ b/Generator/Commands/MailGenerator.php
@@ -41,7 +41,7 @@ class MailGenerator extends GeneratorCommand implements ComponentsGenerator
      *
      * @var  string
      */
-    protected $pathStructure = '{container-name}/Mail/*';
+    protected $pathStructure = '{container-name}/Mails/*';
 
     /**
      * The structure of the file name.

--- a/Generator/Stubs/mail.stub
+++ b/Generator/Stubs/mail.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Containers\{{container-name}}\Mail;
+namespace App\Containers\{{container-name}}\Mails;
 
 use App\Containers\User\Models\User;
 use App\Ship\Parents\Mails\Mail;


### PR DESCRIPTION
according to apiato docs, mails should live in Mails/ folder.