### PR TITLE
move callIncludeMethod() to core

### DIFF
--- a/Abstracts/Transformers/Transformer.php
+++ b/Abstracts/Transformers/Transformer.php
@@ -2,7 +2,13 @@
 
 namespace Apiato\Core\Abstracts\Transformers;
 
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use Apiato\Core\Exceptions\UnsupportedFractalIncludeException;
 use Apiato\Core\Foundation\Facades\Apiato;
+use ErrorException;
+use Exception;
+use Illuminate\Support\Facades\Config;
+use League\Fractal\Scope;
 use League\Fractal\TransformerAbstract as FractalTransformer;
 
 /**
@@ -71,6 +77,30 @@ abstract class Transformer extends FractalTransformer
         }
 
         return parent::collection($data, $transformer, $resourceKey);
+    }
+
+    /**
+     * @param Scope  $scope
+     * @param string $includeName
+     * @param mixed  $data
+     *
+     * @return \League\Fractal\Resource\ResourceInterface
+     * @throws CoreInternalErrorException
+     * @throws UnsupportedFractalIncludeException
+     */
+    protected function callIncludeMethod(Scope $scope, $includeName, $data)
+    {
+        try {
+            return parent::callIncludeMethod($scope, $includeName, $data);
+        }
+        catch (ErrorException $exception) {
+            if (Config::get('apiato.requests.force-valid-includes', true)) {
+                throw new UnsupportedFractalIncludeException();
+            }
+        }
+        catch (Exception $exception) {
+            throw new CoreInternalErrorException();
+        }
     }
 
 }

--- a/Exceptions/CoreInternalErrorException.php
+++ b/Exceptions/CoreInternalErrorException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Apiato\Core\Exceptions;
+
+use App\Ship\Parents\Exceptions\Exception;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+/**
+ * Class CoreInternalErrorException
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class CoreInternalErrorException extends Exception
+{
+
+    public $httpStatusCode = SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR;
+
+    public $message = 'Something went wrong!';
+
+}

--- a/Exceptions/UnsupportedFractalIncludeException.php
+++ b/Exceptions/UnsupportedFractalIncludeException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Apiato\Core\Exceptions;
+
+use App\Ship\Parents\Exceptions\Exception;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+/**
+ * Class UnsupportedFractalIncludeException.
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class UnsupportedFractalIncludeException extends Exception
+{
+
+    public $httpStatusCode = SymfonyResponse::HTTP_BAD_REQUEST;
+
+    public $message = 'Requested a invalid Include Parameter.';
+
+}


### PR DESCRIPTION
This moves the `callINcludeMethod()` from the Ship to the Core. See the other PR in `apiato/apiato` as well ( https://github.com/apiato/apiato/pull/299 )!