### PR TITLE
mapInput() for Requests

### DIFF
--- a/Abstracts/Requests/Request.php
+++ b/Abstracts/Requests/Request.php
@@ -149,6 +149,34 @@ abstract class Request extends LaravelRequest
     }
 
     /**
+     * Maps Keys in the Request.
+     *
+     * For example, ['data.attributes.name' => 'firstname'] would map the field [data][attributes][name] to [firstname].
+     * Note that the old value (data.attributes.name) is removed the original request - this method manipulates the request!
+     * Be sure you know what you do!
+     *
+     * @param array $fields
+     */
+    public function mapInput(array $fields)
+    {
+        $data = $this->all();
+
+        foreach ($fields as $oldKey => $newKey) {
+            // the key to be mapped does not exist - skip it
+            if (!array_has($data, $oldKey)) {
+                continue;
+            }
+
+            // set the new field and remove the old one
+            array_set($data, $newKey, array_get($data, $oldKey));
+            array_forget($data, $oldKey);
+        }
+
+        // overwrite the initial request
+        $this->replace($data);
+    }
+
+    /**
      * Recursively intersects 2 arrays based on their keys.
      *
      * @param array $a first array (that keeps the values)


### PR DESCRIPTION
Added a new `mapInput(array)` method for the Request.

This method, in turn, allows mapping "keys" to others. Basically, it "renames" the keys.. This also works with "nested" keys with `dot notation` (as long as they exist).

For example you can do this:
```php
$request->mapInput([
   'phone.work' => 'phone1',
   'phone.home' => 'phone2',
]);
``` 

This would rename the keys `phone.work` to `phone1` and `phone.home` to `phone2` respectively. 
> Heads up!
> The `mapInput()` overrides the `$request` content! Keep that in mind!

This can be combined with `sanitizeInput(['phone1', 'phone2'])` as well..