### PR TITLE
Let Requests access property use arrays as well

### DIFF
--- a/Abstracts/Requests/Request.php
+++ b/Abstracts/Requests/Request.php
@@ -273,7 +273,8 @@ abstract class Request extends LaravelRequest
             return [];
         }
 
-        $permissions = explode('|', $this->access['permissions']);
+        $permissions = is_array($this->access['permissions']) ? $this->access['permissions'] :
+            explode('|', $this->access['permissions']);
 
         $hasAccess = array_map(function ($permission) use ($user) {
             // Note: internal return
@@ -294,7 +295,8 @@ abstract class Request extends LaravelRequest
             return [];
         }
 
-        $roles = explode('|', $this->access['roles']);
+        $roles = is_array($this->access['roles']) ? $this->access['roles'] :
+            explode('|', $this->access['roles']);
 
         $hasAccess = array_map(function ($role) use ($user) {
             // Note: internal return


### PR DESCRIPTION
Lets user (of Apiato) use arrays when setting up request's access property:

```php
protected $access = [
    'permissions' => ['manage-users', 'create-users'],
    'roles'       => ['user-manager', 'something-else'],
];
```

as well as piped string

```php
protected $access = [
    'permissions' => 'manage-users|create-users',
    'roles'       => 'user-manager|something-else',
];
```