### PR TITLE
patch the HashIdTrait to use the key for specific HashIds

### DIFF
--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -36,7 +36,7 @@ trait HashIdTrait
     {
         // hash the ID only if hash-id enabled in the config
         if (Config::get('apiato.hash-id')) {
-            return $this->encoder(($key) ? : $this->getKey());
+            return $this->encoder(($key) ? $this->$key : $this->getKey());
         }
 
         return $this->getKey();


### PR DESCRIPTION
That way if the value to hash is null, it will be returned as null and does not use the primary key .

Would this break anything?

Yal