### PR TITLE
fix hashedKey()

### DIFF
--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -32,7 +32,7 @@ trait HashIdTrait
      *
      * @param null $field The field of the model to be hashed
      *
-     * @return  mixed|null
+     * @return  mixed
      */
     public function getHashedKey($field = null)
     {

--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -26,17 +26,27 @@ trait HashIdTrait
     ];
 
     /**
+     * Hashes the value of a field (e.g., ID)
+     *
      * Will be used by the Eloquent Models (since it's used as trait there).
      *
-     * @param null $key
+     * @param null $field The field of the model to be hashed
      *
-     * @return  mixed
+     * @return  mixed|null
      */
-    public function getHashedKey($key = null)
+    public function getHashedKey($field = null)
     {
         // hash the ID only if hash-id enabled in the config
         if (Config::get('apiato.hash-id')) {
-            return $this->encoder(($key) ? : $this->getKey());
+
+            // if no key is set, use the default key name (i.e., id)
+            if ($field === null) {
+                $field = $this->getKeyName();
+            }
+
+            // we need to get the VALUE for this KEY (model field)
+            $value = $this->getAttribute($field);
+            return $this->encoder($value);
         }
 
         return $this->getKey();


### PR DESCRIPTION
Fixes the `getHashedKey()` method as described in https://github.com/apiato/apiato/issues/317 .

The **new** behavior (and that should be the intended one) is as follows:
```php
$entity->getHashedKey(); // => AS BEFORE: Uses keyName (default to 'id') to calculate the hashed value!
$entity->getHashedKey(null); // => AS BEFORE: same as above
$entity->getHashedKey('id'); // uses $entity->id to calculate the hashed value
$entity->getHashedKey('customID'); // uses $entity->customID to calculate the value
$entity->getHashedKey('adfadfq'); // returns "" if the field cannot be found in this model
```

This PR should not break anything, because of the following reasons:
1) If you just used the `->getHashedKey()` method in your Transformers before, the method was called without parameter. This behavior is still the same!
2) The method was already broken before 😄 

