### PR TITLE
update repository stub

### DIFF
--- a/Generator/Stubs/repository.stub
+++ b/Generator/Stubs/repository.stub
@@ -11,12 +11,6 @@ class {{class-name}} extends Repository
 {
 
     /**
-     * The Container Name.
-	 * Must be set when the model has a different name than the container
-	 */
-    protected $container = '{{container-name}}';
-
-    /**
      * @var array
      */
     protected $fieldSearchable = [


### PR DESCRIPTION
Since the container is automatically resolved from the class path now (one of my updates to the apiato core) there's no need to specify a container anymore in the repository class except when someone places a repository in a different container than the model but that's just bad design which we shouldn't support. So you can decide what to do with this pull request :)