### PR TITLE
Remove Generator Command Alias

### DIFF
--- a/Generator/Commands/ActionGenerator.php
+++ b/Generator/Commands/ActionGenerator.php
@@ -60,7 +60,7 @@ class ActionGenerator extends GeneratorCommand implements ComponentsGenerator
 
     /**
      * User required/optional inputs expected to be passed while calling the command.
-     * This is a replacement of the `getArguments` function "which reads whenever it's called".
+     * This is a replacement of the `getArguments` function "which reads from the console whenever it's called".
      *
      * @var  array
      */
@@ -70,7 +70,7 @@ class ActionGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/TaskGenerator.php
+++ b/Generator/Commands/TaskGenerator.php
@@ -60,7 +60,7 @@ class TaskGenerator extends GeneratorCommand implements ComponentsGenerator
 
     /**
      * User required/optional inputs expected to be passed while calling the command.
-     * This is a replacement of the `getArguments` function "which reads whenever it's called".
+     * This is a replacement of the `getArguments` function "which reads from the console whenever it's called".
      *
      * @var  array
      */
@@ -69,8 +69,9 @@ class TaskGenerator extends GeneratorCommand implements ComponentsGenerator
         ['stub', null, InputOption::VALUE_OPTIONAL, 'The stub file to load for this generator.'],
     ];
 
+
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/GeneratorCommand.php
+++ b/Generator/GeneratorCommand.php
@@ -90,8 +90,8 @@ abstract class GeneratorCommand extends Command
     private $fileSystem;
 
     private $defaultInputs = [
-        ['container', 'c', InputOption::VALUE_OPTIONAL, 'The name of the container'],
-        ['file', 'f', InputOption::VALUE_OPTIONAL, 'The name of the file'],
+        ['container', null, InputOption::VALUE_OPTIONAL, 'The name of the container'],
+        ['file', null, InputOption::VALUE_OPTIONAL, 'The name of the file'],
     ];
 
     /**
@@ -108,6 +108,7 @@ abstract class GeneratorCommand extends Command
 
     /**
      * @void
+     *
      * @throws \Apiato\Core\Generator\Exceptions\GeneratorErrorException
      */
     public function handle()
@@ -265,6 +266,13 @@ abstract class GeneratorCommand extends Command
         return $value;
     }
 
+    /**
+     * @param      $param
+     * @param      $question
+     * @param bool $default
+     *
+     * @return mixed
+     */
     protected function checkParameterOrConfirm($param, $question, $default = false)
     {
         // check if we have already have a param set


### PR DESCRIPTION
This PR removes the `c` and `f` option alias for `--container` and `--file`. This one is related to the issue described here https://github.com/apiato/apiato/issues/325
