### PR TITLE
add toTransporter method to Request

### DIFF
--- a/Abstracts/Requests/Request.php
+++ b/Abstracts/Requests/Request.php
@@ -2,6 +2,7 @@
 
 namespace Apiato\Core\Abstracts\Requests;
 
+use Apiato\Core\Abstracts\Transporters\Transporter;
 use Apiato\Core\Exceptions\UndefinedTransporterException;
 use Apiato\Core\Traits\HashIdTrait;
 use Apiato\Core\Traits\SanitizerTrait;
@@ -292,6 +293,18 @@ abstract class Request extends LaravelRequest
         }
 
         return $this->transporter;
+    }
+
+    /**
+     * Transforms the Request into a specified Transporter class.
+     *
+     * @return Transporter
+     */
+    public function toTransporter()
+    {
+        $transporterClass = $this->getTransporter();
+        $transporter = new $transporterClass($this);
+        return $transporter;
     }
 
 }


### PR DESCRIPTION
This PR adds the `Request::toTransporter()` method.. This method, in turn, allows for creating a `Transporter` based on a given `Request`. Furthermore, it uses the `protected $transporter` property from `Request` in order to create the specified class.. 