### PR TITLE
[Generator] Transporter

### DIFF
--- a/Generator/Commands/ConfigurationGenerator.php
+++ b/Generator/Commands/ConfigurationGenerator.php
@@ -66,7 +66,7 @@ class ConfigurationGenerator extends GeneratorCommand implements ComponentsGener
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ContainerApiGenerator.php
+++ b/Generator/Commands/ContainerApiGenerator.php
@@ -68,6 +68,7 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
         ['docversion', null, InputOption::VALUE_OPTIONAL, 'The version of all endpoints to be generated (1, 2, ...)'],
         ['doctype', null, InputOption::VALUE_OPTIONAL, 'The type of all endpoints to be generated (private, public)'],
         ['url', null, InputOption::VALUE_OPTIONAL, 'The base URI of all endpoints (/stores, /cars, ...)'],
+        ['transporters', null, InputOption::VALUE_OPTIONAL, 'Use specific Transporters or rely on the generic DataTransporter'],
     ];
 
     /**
@@ -76,6 +77,8 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
     public function getUserInputs()
     {
         $ui = 'api';
+
+        $useTransporters = $this->checkParameterOrConfirm('transporters', 'Would you like to use specific Transporters?', true);
 
         // containername as inputted and lower
         $containerName = $this->containerName;
@@ -147,74 +150,81 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
 
         $routes = [
             [
-                'stub'      => 'GetAll',
-                'name'      => 'GetAll' . $models,
-                'operation' => 'getAll' . $models,
-                'verb'      => 'GET',
-                'url'       => $url,
-                'action'    => 'GetAll' . $models . 'Action',
-                'request'   => 'GetAll' . $models . 'Request',
-                'task'      => 'GetAll' . $models . 'Task',
+                'stub'        => 'GetAll',
+                'name'        => 'GetAll' . $models,
+                'operation'   => 'getAll' . $models,
+                'verb'        => 'GET',
+                'url'         => $url,
+                'action'      => 'GetAll' . $models . 'Action',
+                'request'     => 'GetAll' . $models . 'Request',
+                'task'        => 'GetAll' . $models . 'Task',
+                'transporter' => 'GetAll' . $models . 'Transporter',
             ],
             [
-                'stub'      => 'Find',
-                'name'      => 'Find' . $model . 'ById',
-                'operation' => 'find' . $model . 'ById',
-                'verb'      => 'GET',
-                'url'       => $url . '/{id}',
-                'action'    => 'Find' . $model . 'ById' . 'Action',
-                'request'   => 'Find' . $model . 'ById' . 'Request',
-                'task'      => 'Find' . $model . 'ById' . 'Task',
+                'stub'        => 'Find',
+                'name'        => 'Find' . $model . 'ById',
+                'operation'   => 'find' . $model . 'ById',
+                'verb'        => 'GET',
+                'url'         => $url . '/{id}',
+                'action'      => 'Find' . $model . 'ById' . 'Action',
+                'request'     => 'Find' . $model . 'ById' . 'Request',
+                'task'        => 'Find' . $model . 'ById' . 'Task',
+                'transporter' => 'Find' . $model . 'ById' . 'Transporter',
             ],
             [
-                'stub'      => 'Create',
-                'name'      => 'Create' . $model,
-                'operation' => 'create' . $model,
-                'verb'      => 'POST',
-                'url'       => $url,
-                'action'    => 'Create' . $model . 'Action',
-                'request'   => 'Create' . $model . 'Request',
-                'task'      => 'Create' . $model . 'Task',
+                'stub'        => 'Create',
+                'name'        => 'Create' . $model,
+                'operation'   => 'create' . $model,
+                'verb'        => 'POST',
+                'url'         => $url,
+                'action'      => 'Create' . $model . 'Action',
+                'request'     => 'Create' . $model . 'Request',
+                'task'        => 'Create' . $model . 'Task',
+                'transporter' => 'Create' . $model . 'Transporter',
             ],
             [
-                'stub'      => 'Update',
-                'name'      => 'Update' . $model,
-                'operation' => 'update' . $model,
-                'verb'      => 'PATCH',
-                'url'       => $url . '/{id}',
-                'action'    => 'Update' . $model . 'Action',
-                'request'   => 'Update' . $model . 'Request',
-                'task'      => 'Update' . $model . 'Task',
+                'stub'        => 'Update',
+                'name'        => 'Update' . $model,
+                'operation'   => 'update' . $model,
+                'verb'        => 'PATCH',
+                'url'         => $url . '/{id}',
+                'action'      => 'Update' . $model . 'Action',
+                'request'     => 'Update' . $model . 'Request',
+                'task'        => 'Update' . $model . 'Task',
+                'transporter' => 'Update' . $model . 'Transporter',
             ],
             [
-                'stub'      => 'Delete',
-                'name'      => 'Delete' . $model,
-                'operation' => 'delete' . $model,
-                'verb'      => 'DELETE',
-                'url'       => $url . '/{id}',
-                'action'    => 'Delete' . $model . 'Action',
-                'request'   => 'Delete' . $model . 'Request',
-                'task'      => 'Delete' . $model . 'Task',
+                'stub'        => 'Delete',
+                'name'        => 'Delete' . $model,
+                'operation'   => 'delete' . $model,
+                'verb'        => 'DELETE',
+                'url'         => $url . '/{id}',
+                'action'      => 'Delete' . $model . 'Action',
+                'request'     => 'Delete' . $model . 'Request',
+                'task'        => 'Delete' . $model . 'Task',
+                'transporter' => 'Delete' . $model . 'Transporter',
             ],
         ];
 
         foreach ($routes as $route)
         {
             $this->call('apiato:generate:route', [
-                '--container'   => $containerName,
-                '--file'        => $route['name'],
-                '--ui'          => $ui,
-                '--operation'   => $route['operation'],
-                '--doctype'     => $doctype,
-                '--docversion'  => $version,
-                '--url'         => $route['url'],
-                '--verb'        => $route['verb'],
+                '--container' => $containerName,
+                '--file' => $route['name'],
+                '--ui' => $ui,
+                '--operation' => $route['operation'],
+                '--doctype' => $doctype,
+                '--docversion' => $version,
+                '--url' => $route['url'],
+                '--verb' => $route['verb'],
             ]);
 
             $this->call('apiato:generate:request', [
-                '--container'   => $containerName,
-                '--file'        => $route['request'],
-                '--ui'          => $ui,
+                '--container' => $containerName,
+                '--file' => $route['request'],
+                '--ui' => $ui,
+                '--transporter' => $useTransporters,
+                '--transportername' => $route['transporter'],
             ]);
 
             $this->call('apiato:generate:action', [

--- a/Generator/Commands/ContainerApiGenerator.php
+++ b/Generator/Commands/ContainerApiGenerator.php
@@ -71,7 +71,7 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ContainerGenerator.php
+++ b/Generator/Commands/ContainerGenerator.php
@@ -65,6 +65,7 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
      */
     public $inputs = [
         ['ui', null, InputOption::VALUE_OPTIONAL, 'The user-interface to generate the Controller for.'],
+        ['transporters', null, InputOption::VALUE_OPTIONAL, 'Use specific Transporters or rely on the generic DataTransporter'],
     ];
 
     /**
@@ -74,21 +75,25 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
     {
         $ui = Str::lower($this->checkParameterOrChoice('ui', 'Select the UI for this container', ['API', 'WEB', 'BOTH'], 0));
 
+        $useTransporters = $this->checkParameterOrConfirm('transporters', 'Would you like to use specific Transporters', true);
+
         // containername as inputted and lower
         $containerName = $this->containerName;
         $_containerName = Str::lower($this->containerName);
 
         if ($ui == 'api' || $ui == 'both') {
             $this->call('apiato:generate:container:api', [
-                '--container'   => $containerName,
-                '--file'        => 'composer',
+                '--container'    => $containerName,
+                '--file'         => 'composer',
+                '--transporters' => $useTransporters,
             ]);
         }
 
         if ($ui == 'web' || $ui == 'both') {
             $this->call('apiato:generate:container:web', [
-                '--container'   => $containerName,
-                '--file'        => 'composer',
+                '--container'    => $containerName,
+                '--file'         => 'composer',
+                '--transporters' => $useTransporters,
             ]);
         }
 

--- a/Generator/Commands/ContainerGenerator.php
+++ b/Generator/Commands/ContainerGenerator.php
@@ -68,7 +68,7 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ContainerWebGenerator.php
+++ b/Generator/Commands/ContainerWebGenerator.php
@@ -66,6 +66,7 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
      */
     public $inputs = [
         ['url', null, InputOption::VALUE_OPTIONAL, 'The base URI of all endpoints (/stores, /cars, ...)'],
+        ['transporters', null, InputOption::VALUE_OPTIONAL, 'Use specific Transporters or rely on the generic DataTransporter'],
     ];
 
     /**
@@ -74,6 +75,8 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
     public function getUserInputs()
     {
         $ui = 'web';
+
+        $useTransporters = $this->checkParameterOrConfirm('transporters', 'Would you like to use specific Transporters?', true);
 
         // containername as inputted and lower
         $containerName = $this->containerName;
@@ -136,74 +139,81 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
 
         $routes = [
             [
-                'stub'      => 'GetAll',
-                'name'      => 'GetAll' . $models,
-                'operation' => 'index',
-                'verb'      => 'GET',
-                'url'       => $url,
-                'action'    => 'GetAll' . $models . 'Action',
-                'request'   => 'GetAll' . $models . 'Request',
-                'task'      => 'GetAll' . $models . 'Task',
+                'stub'        => 'GetAll',
+                'name'        => 'GetAll' . $models,
+                'operation'   => 'index',
+                'verb'        => 'GET',
+                'url'         => $url,
+                'action'      => 'GetAll' . $models . 'Action',
+                'request'     => 'GetAll' . $models . 'Request',
+                'task'        => 'GetAll' . $models . 'Task',
+                'transporter' => 'GetAll' . $models . 'Transporter',
             ],
             [
-                'stub'      => 'Find',
-                'name'      => 'Find' . $model . 'ById',
-                'operation' => 'show',
-                'verb'      => 'GET',
-                'url'       => $url . '/{id}',
-                'action'    => 'Find' . $model . 'ById' . 'Action',
-                'request'   => 'Find' . $model . 'ById' . 'Request',
-                'task'      => 'Find' . $model . 'ById' . 'Task',
+                'stub'        => 'Find',
+                'name'        => 'Find' . $model . 'ById',
+                'operation'   => 'show',
+                'verb'        => 'GET',
+                'url'         => $url . '/{id}',
+                'action'      => 'Find' . $model . 'ById' . 'Action',
+                'request'     => 'Find' . $model . 'ById' . 'Request',
+                'task'        => 'Find' . $model . 'ById' . 'Task',
+                'transporter' => 'Find' . $model . 'ById' . 'Transporter',
             ],
             [
-                'stub'      => null,
-                'name'      => 'Create' . $model,
-                'operation' => 'create',
-                'verb'      => 'GET',
-                'url'       => $url . '/create',
-                'action'    => null,
-                'request'   => 'Create' . $model . 'Request',
-                'task'      => null,
+                'stub'        => null,
+                'name'        => 'Create' . $model,
+                'operation'   => 'create',
+                'verb'        => 'GET',
+                'url'         => $url . '/create',
+                'action'      => null,
+                'request'     => 'Create' . $model . 'Request',
+                'task'        => null,
+                'transporter' => null,
             ],
             [
-                'stub'      => 'Create',
-                'name'      => 'Store' . $model,
-                'operation' => 'store',
-                'verb'      => 'POST',
-                'url'       => $url . '/store',
-                'action'    => 'Create' . $model . 'Action',
-                'request'   => 'Store' . $model . 'Request',
-                'task'      => 'Create' . $model . 'Task',
+                'stub'        => 'Create',
+                'name'        => 'Store' . $model,
+                'operation'   => 'store',
+                'verb'        => 'POST',
+                'url'         => $url . '/store',
+                'action'      => 'Create' . $model . 'Action',
+                'request'     => 'Store' . $model . 'Request',
+                'task'        => 'Create' . $model . 'Task',
+                'transporter' => 'Create' . $model . 'Transporter'
             ],
             [
-                'stub'      => null,
-                'name'      => 'Edit' . $model,
-                'operation' => 'edit',
-                'verb'      => 'GET',
-                'url'       => $url . '/{id}/edit',
-                'action'    => null,
-                'request'   => 'Edit' . $model . 'Request',
-                'task'      => null,
+                'stub'        => null,
+                'name'        => 'Edit' . $model,
+                'operation'   => 'edit',
+                'verb'        => 'GET',
+                'url'         => $url . '/{id}/edit',
+                'action'      => null,
+                'request'     => 'Edit' . $model . 'Request',
+                'task'        => null,
+                'transporter' => null,
             ],
             [
-                'stub'      => 'Update',
-                'name'      => 'Update' . $model,
-                'operation' => 'update',
-                'verb'      => 'PATCH',
-                'url'       => $url . '/{id}',
-                'action'    => 'Update' . $model . 'Action',
-                'request'   => 'Update' . $model . 'Request',
-                'task'      => 'Update' . $model . 'Task',
+                'stub'        => 'Update',
+                'name'        => 'Update' . $model,
+                'operation'   => 'update',
+                'verb'        => 'PATCH',
+                'url'         => $url . '/{id}',
+                'action'      => 'Update' . $model . 'Action',
+                'request'     => 'Update' . $model . 'Request',
+                'task'        => 'Update' . $model . 'Task',
+                'transporter' => 'Update' . $model . 'Transporter',
             ],
             [
-                'stub'      => 'Delete',
-                'name'      => 'Delete' . $model,
-                'operation' => 'delete',
-                'verb'      => 'DELETE',
-                'url'       => $url . '/{id}',
-                'action'    => 'Delete' . $model . 'Action',
-                'request'   => 'Delete' . $model . 'Request',
-                'task'      => 'Delete' . $model . 'Task',
+                'stub'        => 'Delete',
+                'name'        => 'Delete' . $model,
+                'operation'   => 'delete',
+                'verb'        => 'DELETE',
+                'url'         => $url . '/{id}',
+                'action'      => 'Delete' . $model . 'Action',
+                'request'     => 'Delete' . $model . 'Request',
+                'task'        => 'Delete' . $model . 'Task',
+                'transporter' => 'Delete' . $model . 'Transporter',
             ],
         ];
 
@@ -220,10 +230,19 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
                 '--verb'        => $route['verb'],
             ]);
 
+            $enableTransporter = false;
+            if ($useTransporters) {
+                if ($route['transporter'] != null) {
+                    $enableTransporter = true;
+                }
+            }
+
             $this->call('apiato:generate:request', [
                 '--container'   => $containerName,
                 '--file'        => $route['request'],
                 '--ui'          => $ui,
+                '--transporter' => $enableTransporter,
+                '--transportername' => $route['transporter'],
             ]);
 
             if ($route['action'] != null || $route['stub'] != null) {

--- a/Generator/Commands/ContainerWebGenerator.php
+++ b/Generator/Commands/ContainerWebGenerator.php
@@ -69,7 +69,7 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/EventGenerator.php
+++ b/Generator/Commands/EventGenerator.php
@@ -69,7 +69,7 @@ class EventGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/EventHandlerGenerator.php
+++ b/Generator/Commands/EventHandlerGenerator.php
@@ -67,7 +67,7 @@ class EventHandlerGenerator extends GeneratorCommand implements ComponentsGenera
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ExceptionGenerator.php
+++ b/Generator/Commands/ExceptionGenerator.php
@@ -66,7 +66,7 @@ class ExceptionGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/JobGenerator.php
+++ b/Generator/Commands/JobGenerator.php
@@ -66,7 +66,7 @@ class JobGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/MailGenerator.php
+++ b/Generator/Commands/MailGenerator.php
@@ -68,7 +68,7 @@ class MailGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/MigrationGenerator.php
+++ b/Generator/Commands/MigrationGenerator.php
@@ -70,7 +70,7 @@ class MigrationGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array|null
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ModelGenerator.php
+++ b/Generator/Commands/ModelGenerator.php
@@ -69,7 +69,7 @@ class ModelGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/NotificationGenerator.php
+++ b/Generator/Commands/NotificationGenerator.php
@@ -66,7 +66,7 @@ class NotificationGenerator extends GeneratorCommand implements ComponentsGenera
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ReadmeGenerator.php
+++ b/Generator/Commands/ReadmeGenerator.php
@@ -66,7 +66,7 @@ class ReadmeGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/RepositoryGenerator.php
+++ b/Generator/Commands/RepositoryGenerator.php
@@ -66,7 +66,7 @@ class RepositoryGenerator extends GeneratorCommand implements ComponentsGenerato
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/RequestGenerator.php
+++ b/Generator/Commands/RequestGenerator.php
@@ -68,7 +68,7 @@ class RequestGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/RequestGenerator.php
+++ b/Generator/Commands/RequestGenerator.php
@@ -75,7 +75,7 @@ class RequestGenerator extends GeneratorCommand implements ComponentsGenerator
     public function getUserInputs()
     {
         $ui = Str::lower($this->checkParameterOrChoice('ui', 'Select the UI for the controller', ['API', 'WEB'], 0));
-        $transporter = Str::lower($this->checkParameterOrConfirm('transporter', 'Would you like to create a corresponding Transporter for this Request?', true));
+        $transporter = $this->checkParameterOrConfirm('transporter', 'Would you like to create a corresponding Transporter for this Request?', true);
 
         if ($transporter) {
             $transporterName = $this->checkParameterOrAsk('transportername', 'Enter the Name of the corresponding Transporter to be assigned');

--- a/Generator/Commands/SeederGenerator.php
+++ b/Generator/Commands/SeederGenerator.php
@@ -66,7 +66,7 @@ class SeederGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ServiceProviderGenerator.php
+++ b/Generator/Commands/ServiceProviderGenerator.php
@@ -68,7 +68,7 @@ class ServiceProviderGenerator extends GeneratorCommand implements ComponentsGen
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/SubActionGenerator.php
+++ b/Generator/Commands/SubActionGenerator.php
@@ -66,7 +66,7 @@ class SubActionGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/TaskGenerator.php
+++ b/Generator/Commands/TaskGenerator.php
@@ -69,7 +69,6 @@ class TaskGenerator extends GeneratorCommand implements ComponentsGenerator
         ['stub', null, InputOption::VALUE_OPTIONAL, 'The stub file to load for this generator.'],
     ];
 
-
     /**
      * @return array
      */

--- a/Generator/Commands/TransformerGenerator.php
+++ b/Generator/Commands/TransformerGenerator.php
@@ -70,7 +70,7 @@ class TransformerGenerator extends GeneratorCommand implements ComponentsGenerat
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/TransporterGenerator.php
+++ b/Generator/Commands/TransporterGenerator.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Apiato\Core\Generator\Commands;
+
+use Apiato\Core\Generator\GeneratorCommand;
+use Apiato\Core\Generator\Interfaces\ComponentsGenerator;
+use Illuminate\Support\Str;
+
+/**
+ * Class TransporterGenerator
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class TransporterGenerator extends GeneratorCommand implements ComponentsGenerator
+{
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'apiato:generate:transporter';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Transporter class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $fileType = 'Transporter';
+
+    /**
+     * The structure of the file path.
+     *
+     * @var  string
+     */
+    protected $pathStructure = '{container-name}/Data/Transporters/*';
+
+    /**
+     * The structure of the file name.
+     *
+     * @var  string
+     */
+    protected $nameStructure = '{file-name}';
+
+    /**
+     * The name of the stub file.
+     *
+     * @var  string
+     */
+    protected $stubName = 'transporter.stub';
+
+    /**
+     * User required/optional inputs expected to be passed while calling the command.
+     * This is a replacement of the `getArguments` function "which reads whenever it's called".
+     *
+     * @var  array
+     */
+    public $inputs = [
+
+    ];
+
+    /**
+     * @return array
+     */
+    public function getUserInputs()
+    {
+        return [
+            'path-parameters' => [
+                'container-name' => $this->containerName,
+            ],
+            'stub-parameters' => [
+                '_container-name' => Str::lower($this->containerName),
+                'container-name'  => $this->containerName,
+                'class-name'      => $this->fileName,
+            ],
+            'file-parameters' => [
+                'file-name' => $this->fileName,
+            ],
+        ];
+    }
+
+    public function getDefaultFileName()
+    {
+        return 'DefaultTransporter';
+    }
+}

--- a/Generator/Commands/ValueGenerator.php
+++ b/Generator/Commands/ValueGenerator.php
@@ -67,7 +67,7 @@ class ValueGenerator extends GeneratorCommand implements ComponentsGenerator
     ];
 
     /**
-     * urn mixed|void
+     * @return array
      */
     public function getUserInputs()
     {

--- a/Generator/Commands/ValueGenerator.php
+++ b/Generator/Commands/ValueGenerator.php
@@ -8,11 +8,11 @@ use Illuminate\Support\Pluralizer;
 use Illuminate\Support\Str;
 
 /**
- * Class ValueObjectGenerator
+ * Class ValueGenerator
  *
  * @author  Mahmoud Zalt  <mahmoud@zalt.me>
  */
-class ValueObjectGenerator extends GeneratorCommand implements ComponentsGenerator
+class ValueGenerator extends GeneratorCommand implements ComponentsGenerator
 {
 
     /**

--- a/Generator/GeneratorCommand.php
+++ b/Generator/GeneratorCommand.php
@@ -277,15 +277,13 @@ abstract class GeneratorCommand extends Command
     {
         // check if we have already have a param set
         $value = $this->option($param);
-        if($value == null)
+        if ($value === null)
         {
             // there was no value provided via CLI, so ask the user..
             $value = $this->confirm($question, $default);
         }
 
-        // we need to parse the output value to a boolean value, as the values are strings (e.g., "true"), when they
-        // are read from the command line...
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        return $value;
     }
 
     /**

--- a/Generator/GeneratorsServiceProvider.php
+++ b/Generator/GeneratorsServiceProvider.php
@@ -25,7 +25,7 @@ use Apiato\Core\Generator\Commands\ServiceProviderGenerator;
 use Apiato\Core\Generator\Commands\SubActionGenerator;
 use Apiato\Core\Generator\Commands\TaskGenerator;
 use Apiato\Core\Generator\Commands\TransformerGenerator;
-use Apiato\Core\Generator\Commands\ValueObjectGenerator;
+use Apiato\Core\Generator\Commands\ValueGenerator;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -78,7 +78,7 @@ class GeneratorsServiceProvider extends ServiceProvider
             SubActionGenerator::class,
             TaskGenerator::class,
             TransformerGenerator::class,
-            ValueObjectGenerator::class,
+            ValueGenerator::class,
         ]);
     }
 

--- a/Generator/GeneratorsServiceProvider.php
+++ b/Generator/GeneratorsServiceProvider.php
@@ -25,6 +25,7 @@ use Apiato\Core\Generator\Commands\ServiceProviderGenerator;
 use Apiato\Core\Generator\Commands\SubActionGenerator;
 use Apiato\Core\Generator\Commands\TaskGenerator;
 use Apiato\Core\Generator\Commands\TransformerGenerator;
+use Apiato\Core\Generator\Commands\TransporterGenerator;
 use Apiato\Core\Generator\Commands\ValueGenerator;
 use Illuminate\Support\ServiceProvider;
 
@@ -78,6 +79,7 @@ class GeneratorsServiceProvider extends ServiceProvider
             SubActionGenerator::class,
             TaskGenerator::class,
             TransformerGenerator::class,
+            TransporterGenerator::class,
             ValueGenerator::class,
         ]);
     }

--- a/Generator/Stubs/request.stub
+++ b/Generator/Stubs/request.stub
@@ -9,6 +9,14 @@ use App\Ship\Parents\Requests\Request;
  */
 class {{class-name}} extends Request
 {
+
+    /**
+     * The assigned Transporter for this Request
+     *
+     * @var string
+     */
+    {{transporterEnabled}}protected $transporter = {{transporterClass}};
+
     /**
      * Define which Roles and/or Permissions has access to this request.
      *

--- a/Generator/Stubs/transporter.stub
+++ b/Generator/Stubs/transporter.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Containers\{{container-name}}\Data\Transporters;
+
+use App\Ship\Parents\Transporters\Transporter;
+
+class {{class-name}} extends Transporter
+{
+
+    /**
+     * @var array
+     */
+    protected $schema = [
+        'type' => 'object',
+        'properties' => [
+            // enter all properties here
+
+            // allow for undefined properties
+            // 'additionalProperties' => true,
+        ],
+        'required'   => [
+            // define the properties that MUST be set
+        ],
+        'default'    => [
+            // provide default values for specific properties here
+        ]
+    ];
+}


### PR DESCRIPTION
This PR provides a `Generator` in order to automatically create `Transporters`..
What it does:
- It provides a Generator for the `Transporter` object
- When creating a `Request`, it asks the user if he wants to also create the corresponding `Transporter`. If he selects `yes`, he is asked for the respective classname (e.g., `UpdateUserTransporter`). This `Transporter` is then set as `protected $transporter` within the generated `Request` class! If no corresponding `Transporter` shall be created, a `// protected $transporter = DataTransporter::class;` is added in order to indicate, how this feature may be enabled! In this specific case (i.e., no `Transporter` is defined), the implementation "falls back" to the `DataTransporter` anyways.
- The `Container(API/WEB)Generators` are also adapted in order to create the `Transporters`. On this "level", however, the developer is asked, if he would like to use `specific Transporters` (`yes`: For each `Request`, a corresponding `Transporter` is created (e.g., `GetAllUsersRequest` creates a `GetAllUsersTransporter`); `no`: No `Transporters` are created).

Minor things:
- Changed the ClassName `ValueObjectGenerator` to `ValueGenerator` (in order to reflect the change from efe2f97991f10278164981365d72d0ad98ffcd91)
- Fixed a small issue with `askOrConfirm()` method
- Fixed some DocBlocks in the Generators

Cheers 😀 