### PR TITLE
Laravel 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+## v2.3.*
+This is `apiato/core` that works with `laravel 5.6`
+
+### Added
+
+### Fixed
+
+### Changed
+- Updated Dependencies in `composer.json` file to the latest versions
+
+### Removed
+

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "apiato/containers-installer" : "1.0.*",
     "guzzlehttp/guzzle": "^6.3",
     "prettus/l5-repository": "^2.6",
-    "barryvdh/laravel-cors": "0.9.*",
-    "spatie/laravel-fractal": "5.0.*",
+    "barryvdh/laravel-cors": "^0.11",
+    "spatie/laravel-fractal": "5.3.*",
     "vinkla/hashids": "^3.2",
     "optimus/heimdal" : "~1.5",
     "dto/dto" : "^3.2"


### PR DESCRIPTION
Start working on a `core` that supports laravel 5.6.
Note that this PR - at first - only updates dependencies. Most of the changes may be subject to `apiato/apiato` but not to the core. However, as additional changes may be required, i will add other PRs for the core