### PR TITLE
Unexpected behavior on null attribute value

### DIFF
--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -45,7 +45,8 @@ trait HashIdTrait
         if (Config::get('apiato.hash-id')) {
             // we need to get the VALUE for this KEY (model field)
             $value = $this->getAttribute($field);
-            return $this->encoder($value);
+            
+            return is_null($value) ? null : $this->encoder($value);
         }
 
         return $this->getAttribute($field);


### PR DESCRIPTION
An update to the previous hash id improvement. 
When using nullable values the key is still hashed. 
The library returns an empty string when no value is given. 
This is breaking for a lot of JSON API
