### PR TITLE
Fix Repository

### DIFF
--- a/Abstracts/Actions/Action.php
+++ b/Abstracts/Actions/Action.php
@@ -3,6 +3,7 @@
 namespace Apiato\Core\Abstracts\Actions;
 
 use Apiato\Core\Traits\CallableTrait;
+use Apiato\Core\Traits\HasRequestCriteriaTrait;
 
 /**
  * Class Action.
@@ -13,6 +14,7 @@ abstract class Action
 {
 
     use CallableTrait;
+    use HasRequestCriteriaTrait;
 
     /**
      * Set automatically by the controller after calling an Action.

--- a/Abstracts/Repositories/Repository.php
+++ b/Abstracts/Repositories/Repository.php
@@ -51,7 +51,10 @@ abstract class Repository extends PrettusRepository implements PrettusCacheable
      */
     public function boot()
     {
-        $this->pushCriteria(app(PrettusRequestCriteria::class));
+        // only apply the RequestCriteria if config flag is set!
+        if (Config::get('apiato.requests.automatically-apply-request-criteria', true)) {
+            $this->pushCriteria(app(PrettusRequestCriteria::class));
+        }
     }
 
     /**
@@ -74,7 +77,7 @@ abstract class Repository extends PrettusRepository implements PrettusCacheable
         $limit = $limit ? : Request::get('limit');
 
         // check, if skipping pagination is allowed and the requested by the user
-        if(Config::get('repository.pagination.skip') && $limit == "0") {
+        if (Config::get('repository.pagination.skip') && $limit == "0") {
             return parent::all($columns);
         }
 

--- a/Abstracts/Tasks/Task.php
+++ b/Abstracts/Tasks/Task.php
@@ -2,6 +2,8 @@
 
 namespace Apiato\Core\Abstracts\Tasks;
 
+use Apiato\Core\Traits\HasRequestCriteriaTrait;
+
 /**
  * Class Task.
  *
@@ -9,5 +11,6 @@ namespace Apiato\Core\Abstracts\Tasks;
  */
 abstract class Task
 {
+    use HasRequestCriteriaTrait;
 
 }

--- a/Generator/Stubs/actions/getall.stub
+++ b/Generator/Stubs/actions/getall.stub
@@ -10,7 +10,7 @@ class GetAll{{models}}Action extends Action
 {
     public function run(Request $request)
     {
-        ${{entities}} = Apiato::call('{{container-name}}@GetAll{{models}}Task');
+        ${{entities}} = Apiato::call('{{container-name}}@GetAll{{models}}Task', [], ['addRequestCriteria');
 
         return ${{entities}};
     }

--- a/Generator/Stubs/actions/getall.stub
+++ b/Generator/Stubs/actions/getall.stub
@@ -10,7 +10,7 @@ class GetAll{{models}}Action extends Action
 {
     public function run(Request $request)
     {
-        ${{entities}} = Apiato::call('{{container-name}}@GetAll{{models}}Task', [], ['addRequestCriteria');
+        ${{entities}} = Apiato::call('{{container-name}}@GetAll{{models}}Task', [], ['addRequestCriteria']);
 
         return ${{entities}};
     }

--- a/Generator/Stubs/tasks/create.stub
+++ b/Generator/Stubs/tasks/create.stub
@@ -10,7 +10,7 @@ use Exception;
 class Create{{model}}Task extends Task
 {
 
-    private $repository;
+    protected $repository;
 
     public function __construct({{model}}Repository $repository)
     {

--- a/Generator/Stubs/tasks/delete.stub
+++ b/Generator/Stubs/tasks/delete.stub
@@ -10,7 +10,7 @@ use Exception;
 class Delete{{model}}Task extends Task
 {
 
-    private $repository;
+    protected $repository;
 
     public function __construct({{model}}Repository $repository)
     {

--- a/Generator/Stubs/tasks/find.stub
+++ b/Generator/Stubs/tasks/find.stub
@@ -10,7 +10,7 @@ use Exception;
 class Find{{model}}ByIdTask extends Task
 {
 
-    private $repository;
+    protected $repository;
 
     public function __construct({{model}}Repository $repository)
     {

--- a/Generator/Stubs/tasks/getall.stub
+++ b/Generator/Stubs/tasks/getall.stub
@@ -8,7 +8,7 @@ use App\Ship\Parents\Tasks\Task;
 class GetAll{{models}}Task extends Task
 {
 
-    private $repository;
+    protected $repository;
 
     public function __construct({{model}}Repository $repository)
     {

--- a/Generator/Stubs/tasks/update.stub
+++ b/Generator/Stubs/tasks/update.stub
@@ -10,7 +10,7 @@ use Exception;
 class Update{{model}}Task extends Task
 {
 
-    private $repository;
+    protected $repository;
 
     public function __construct({{model}}Repository $repository)
     {

--- a/Traits/HasRequestCriteriaTrait.php
+++ b/Traits/HasRequestCriteriaTrait.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Apiato\Core\Traits;
+
+use Apiato\Core\Abstracts\Repositories\Repository;
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use Prettus\Repository\Criteria\RequestCriteria;
+
+/**
+ * Trait HasRequestCriteriaTrait
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+trait HasRequestCriteriaTrait
+{
+
+    /**
+     * Adds the RequestCriteria to a Repository
+     *
+     * @param null $repository
+     */
+    public function addRequestCriteria($repository = null)
+    {
+        $validatedRepository = $this->validateRepository($repository);
+
+        $validatedRepository->pushCriteria(app(RequestCriteria::class));
+    }
+
+    /**
+     * Removes the RequestCriteria from a Repository
+     *
+     * @param null $repository
+     */
+    public function removeRequestCriteria($repository = null)
+    {
+        $validatedRepository = $this->validateRepository($repository);
+
+        $validatedRepository->popCriteria(RequestCriteria::class);
+    }
+
+    /**
+     * Validates, if the given Repository exists or uses $this->repository on the Task/Action to apply functions
+     *
+     * @param $repository
+     *
+     * @return mixed
+     * @throws CoreInternalErrorException
+     */
+    private function validateRepository($repository)
+    {
+        $validatedRepository = $repository;
+
+        // check if we have a "custom" repository
+        if (null === $repository) {
+            if (! isset($this->repository)) {
+                throw new CoreInternalErrorException('No protected or public accessible repository available');
+            }
+            $validatedRepository = $this->repository;
+        }
+
+        // check, if the validated repository is null
+        if (null === $validatedRepository) {
+            throw new CoreInternalErrorException();
+        }
+
+        // check if it is a Repository class
+        if (! ($validatedRepository instanceof Repository)) {
+            throw new CoreInternalErrorException();
+        }
+
+        return $validatedRepository;
+    }
+
+}


### PR DESCRIPTION
This PR applies changes to the `core` to fix the issue with `cascading Repositories`.
The issue here is, that the `RequestCriteria` is applied to **all** `Repositories` instead of only to one.

For example, you have a Route that does the following thing:
1) Get All Users
2) Get All Purchases for All Users

If you then call the Route like so: `GET endpoint?search=name:test` this will result in:
1) The `RequestCriteria` will be applied to the `UserRepository` **and** the `PurchaseRepository`.
2) Both repositories are filtered with `name=test`.

The result would be all users that are named `test` and only the purchases that are called `test` for them. So obvioulsy, not the thing you want..

------------

This PR does the following thing:
- It uses a configuration flag to not automatically apply the `RequestCriteria` to all `Repository` classes, however makes it configurable (in `apiato/apiato`). Defaults to `true` in order to not break anything!
- It provides a new `HasRequestCriteriaTrait` that is added to the `Task` and `Action` classes.
- This `Trait` contains functions to add / remove the `RequestCriteria` dynamically.
- It adapts the `Generator Stubs` to use the new format for this (e.g., `$repository` has to be `protected` instead of `private`!)