### PR TITLE
Fix incorrect namespace on Job stub

### DIFF
--- a/Generator/Stubs/job.stub
+++ b/Generator/Stubs/job.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Containers\{{container-name}}\Job;
+namespace App\Containers\{{container-name}}\Jobs;
 
 use App\Ship\Parents\Jobs\Job;
 


### PR DESCRIPTION
Incorrect naming on the namespace, change "Job" to "Jobs".