### PR TITLE
transactionalCall()  method

### DIFF
--- a/Traits/CallableTrait.php
+++ b/Traits/CallableTrait.php
@@ -7,6 +7,7 @@ use Apiato\Core\Abstracts\Transporters\Transporter;
 use Apiato\Core\Foundation\Facades\Apiato;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -40,6 +41,23 @@ trait CallableTrait
         $runMethodArguments = $this->convertRequestsToTransporters($class, $runMethodArguments);
 
         return $class->run(...$runMethodArguments);
+    }
+
+    /**
+     * This function calls another class but wraps it in a DB-Transaction. This might be useful for CREATE / UPDATE / DELETE
+     * operations in order to prevent the database from corrupt data. Internally, the regular call() method is used!
+     *
+     * @param       $class
+     * @param array $runMethodArguments
+     * @param array $extraMethodsToCall
+     *
+     * @return mixed
+     */
+    public function transactionalCall($class, $runMethodArguments = [], $extraMethodsToCall = [])
+    {
+        return DB::transaction(function() use ($class, $runMethodArguments, $extraMethodsToCall) {
+            return $this->call($class, $runMethodArguments, $extraMethodsToCall);
+        });
     }
 
     /**

--- a/Traits/CallableTrait.php
+++ b/Traits/CallableTrait.php
@@ -6,6 +6,7 @@ use Apiato\Core\Abstracts\Requests\Request;
 use Apiato\Core\Abstracts\Transporters\Transporter;
 use Apiato\Core\Foundation\Facades\Apiato;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -64,7 +65,9 @@ trait CallableTrait
 
             Apiato::verifyClassExist($classFullName);
         } else {
-            Log::debug('It is recommended to use the apiato caller style (containerName@className) for ' . $class);
+            if (Config::get('apiato.logging.log-wrong-apiato-caller-style', true)) {
+                Log::debug('It is recommended to use the apiato caller style (containerName@className) for ' . $class);
+            }
         }
 
         return App::make($class);


### PR DESCRIPTION
This PR introduces a new `transactionalCall()` method with the same signature as the well-known `call()` function. However, the `transactionalCall()` wraps respective `call()` function in a `DB::transaction()` in order to keep the database in a consistent state.