### PR TITLE
"Cannot declare class" errors in PHPUnit

### DIFF
--- a/Loaders/FactoryMixer/FactoriesLoader.php
+++ b/Loaders/FactoryMixer/FactoriesLoader.php
@@ -29,7 +29,7 @@ foreach (Apiato::getContainersNames() as $containerName) {
             if (\File::isFile($factoryFile)) {
 
                 // Include the factory files
-                include($factoryFile);
+                require_once $factoryFile;
 
             }
         }


### PR DESCRIPTION
A simple change just in case we have Factories loaded already.