### PR TITLE
Build url considering api prefix for tests

### DIFF
--- a/Traits/TestsTraits/PhpUnit/TestsRequestHelperTrait.php
+++ b/Traits/TestsTraits/PhpUnit/TestsRequestHelperTrait.php
@@ -232,12 +232,13 @@ trait TestsRequestHelperTrait
      */
     private function buildUrlForUri($uri)
     {
-        // add `/` at the beginning in case it doesn't exist
-        if (!Str::startsWith($uri, '/')) {
-            $uri = '/' . $uri;
+        $apiUrl = Config::get('apiato.api.url');
+
+        if (!Str::endsWith($apiUrl, '/')) {
+            $apiUrl .= '/';
         }
 
-        return Config::get('apiato.api.url') . $uri;
+        return $apiUrl . Config::get('apiato.api.prefix') . $uri;
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a failure of tests in case there are customizations of api url using prefix.