### PR TITLE
Fix unused $error

### DIFF
--- a/Abstracts/Exceptions/Exception.php
+++ b/Abstracts/Exceptions/Exception.php
@@ -65,7 +65,7 @@ abstract class Exception extends SymfonyHttpException
         $this->environment = Config::get('app.env');
 
         $message = $this->prepareMessage($message);
-        $error = $this->prepareError($errors);
+        $this->errors = $this->prepareError($errors);
         $statusCode = $this->prepareStatusCode($statusCode);
 
         $this->logTheError($statusCode, $message, $code);


### PR DESCRIPTION
I tried to create my own Exception which extends this exception but seems like it never return the "errors" attribute in response.

I am not sure If this fixes the problem, but I saw that the $error is never used in constructor..

May you check this please? 

Thanks =)