### PR TITLE
Allow string that has delimiter on testing access.

### DIFF
--- a/Traits/TestsTraits/PhpUnit/TestsAuthHelperTrait.php
+++ b/Traits/TestsTraits/PhpUnit/TestsAuthHelperTrait.php
@@ -188,11 +188,13 @@ trait TestsAuthHelperTrait
     {
         if (isset($access['roles']) && !empty($access['roles'])) {
 
-            $roles = is_array($access['roles']) ? $access['roles'] :
-            explode('|', $access['roles']);
+            if(!is_array($access['roles']))
+            {
+                $access['roles'] = explode('|', $access['roles']);
+            }
 
-            if (!$user->hasRole($roles)) {
-                $user->assignRole($roles);
+            if (!$user->hasRole($access['roles'])) {
+                $user->assignRole($access['roles']);
                 $user = $user->fresh();
             }
         }
@@ -210,10 +212,12 @@ trait TestsAuthHelperTrait
     {
         if (isset($access['permissions']) && !empty($access['permissions'])) {
 
-            $permissions = is_array($access['permissions']) ? $access['permissions'] :
-            explode('|', $access['permissions']);
+            if(!is_array($access['permissions']))
+            {
+                $access['permissions'] = explode('|', $access['permissions']);
+            }
 
-            $user->givePermissionTo($permissions);
+            $user->givePermissionTo($access['permissions']);
             $user = $user->fresh();
         }
 

--- a/Traits/TestsTraits/PhpUnit/TestsAuthHelperTrait.php
+++ b/Traits/TestsTraits/PhpUnit/TestsAuthHelperTrait.php
@@ -187,8 +187,12 @@ trait TestsAuthHelperTrait
     private function setupTestingUserRoles($user, $access)
     {
         if (isset($access['roles']) && !empty($access['roles'])) {
-            if (!$user->hasRole($access['roles'])) {
-                $user->assignRole($access['roles']);
+
+            $roles = is_array($access['roles']) ? $access['roles'] :
+            explode('|', $access['roles']);
+
+            if (!$user->hasRole($roles)) {
+                $user->assignRole($roles);
                 $user = $user->fresh();
             }
         }
@@ -205,7 +209,11 @@ trait TestsAuthHelperTrait
     private function setupTestingUserPermissions($user, $access)
     {
         if (isset($access['permissions']) && !empty($access['permissions'])) {
-            $user->givePermissionTo($access['permissions']);
+
+            $permissions = is_array($access['permissions']) ? $access['permissions'] :
+            explode('|', $access['permissions']);
+
+            $user->givePermissionTo($permissions);
             $user = $user->fresh();
         }
 


### PR DESCRIPTION
Allow on test class to set like this

```php

// App\Containers\xx\UI\API\Tests\Functional\GetAllxxxFunctionalTest
    /**
     * Define which Roles and/or Permissions has access to this request.
     *
     * @var  array
     */
    protected $access = [
        'permissions' => 'list-data',
        'roles'       => 'admin|employee',
    ];
```

just like on main `Request`

Thanks :)