### PR TITLE
force-accept-header

### DIFF
--- a/Exceptions/Handlers/ExceptionsHandler.php
+++ b/Exceptions/Handlers/ExceptionsHandler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Foundation\Exceptions\Handler as LaravelExceptionHandler;
 use Illuminate\Support\Facades\Config;
 use Optimus\Heimdal\ExceptionHandler as HeimdalExceptionHandler;
+use App\Ship\Exceptions\MissingJSONHeaderException;
 
 /**
  * Class ExceptionsHandler
@@ -17,7 +18,7 @@ class ExceptionsHandler extends HeimdalExceptionHandler
     public function render($request, Exception $e)
     {
         // if the user expects json or the API forces the user to send it
-        if (($request->expectsJson()) || (Config::get('apiato.requests.force-accept-header'))) {
+        if (($request->expectsJson()) || (Config::get('apiato.requests.force-accept-header') && $e instanceof MissingJSONHeaderException)) {
             // return the error as json
             return parent::render($request, $e);
         }


### PR DESCRIPTION
Hi!, 

If `force-accept-header` is `true` and `MissingJSONHeaderException`
then return json response

to prevent return json on web when `force-accept-header` is set to true,

it is good?

Thanks :)