### PR TITLE
fix: set setUp method of TestCase to protected

### DIFF
--- a/Abstracts/Tests/PhpUnit/TestCase.php
+++ b/Abstracts/Tests/PhpUnit/TestCase.php
@@ -43,7 +43,7 @@ abstract class TestCase extends LaravelTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
     }


### PR DESCRIPTION
The setup Method is a protected method called by PHPUnit internally. It should not be exposed as a public method.