### PR TITLE
Fix FactoryMixer path on unit testing execution (#85).

### DIFF
--- a/Loaders/FactoriesLoaderTrait.php
+++ b/Loaders/FactoriesLoaderTrait.php
@@ -20,15 +20,12 @@ trait FactoriesLoaderTrait
      */
     public function loadFactoriesFromContainers()
     {
-        $loadersDirectory = str_replace(getcwd(), '', __DIR__);
-
-        $newFactoriesPath = $loadersDirectory . '/FactoryMixer';
+        $newFactoriesPath = base_path('vendor/apiato/core/Loaders/FactoryMixer');
 
         App::singleton(Factory::class, function ($app) use ($newFactoriesPath) {
-            $faker = $app->make(Generator::class);
-
-            return Factory::construct($faker, base_path() . $newFactoriesPath);
+            return Factory::construct($app->make(Generator::class), $newFactoriesPath);
         });
     }
 
 }
+


### PR DESCRIPTION
This PR fixes the issue when trying to load the FactoryMixer by removing getcwd which returns different paths depending on the execution context and using Laravel's helping function base_path.