### PR TITLE
Adds a new generator for Command classes

### DIFF
--- a/Generator/Commands/CommandGenerator.php
+++ b/Generator/Commands/CommandGenerator.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Apiato\Core\Generator\Commands;
+
+use Apiato\Core\Generator\GeneratorCommand;
+use Apiato\Core\Generator\Interfaces\ComponentsGenerator;
+use Illuminate\Support\Str;
+
+/**
+ * Class JobGenerator
+ *
+ * @author  Mahmoud Zalt  <mahmoud@zalt.me>
+ */
+class CommandGenerator extends GeneratorCommand implements ComponentsGenerator
+{
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'apiato:generate:command';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Command class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $fileType = 'Command';
+
+    /**
+     * The structure of the file path.
+     *
+     * @var  string
+     */
+    protected $pathStructure = '{container-name}/UI/CLI/Commands/*';
+
+    /**
+     * The structure of the file name.
+     *
+     * @var  string
+     */
+    protected $nameStructure = '{file-name}';
+
+    /**
+     * The name of the stub file.
+     *
+     * @var  string
+     */
+    protected $stubName = 'command.stub';
+
+    /**
+     * User required/optional inputs expected to be passed while calling the command.
+     * This is a replacement of the `getArguments` function "which reads whenever it's called".
+     *
+     * @var  array
+     */
+    public $inputs = [
+    ];
+
+    /**
+     * @return array
+     */
+    public function getUserInputs()
+    {
+        return [
+            'path-parameters' => [
+                'container-name' => $this->containerName,
+            ],
+            'stub-parameters' => [
+                '_container-name' => Str::lower($this->containerName),
+                'container-name'  => $this->containerName,
+                'class-name'      => $this->fileName,
+            ],
+            'file-parameters' => [
+                'file-name' => $this->fileName,
+            ],
+        ];
+    }
+
+    /**
+     * Get the default file name for this component to be generated
+     *
+     * @return string
+     */
+    public function getDefaultFileName()
+    {
+        return 'DefaultCommand';
+    }
+}

--- a/Generator/Commands/CommandGenerator.php
+++ b/Generator/Commands/CommandGenerator.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 /**
  * Class JobGenerator
  *
- * @author  Mahmoud Zalt  <mahmoud@zalt.me>
+ * @author  Claudson Martins  <claudson@outlook.com>
  */
 class CommandGenerator extends GeneratorCommand implements ComponentsGenerator
 {

--- a/Generator/GeneratorsServiceProvider.php
+++ b/Generator/GeneratorsServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Apiato\Core\Generator;
 
 use Apiato\Core\Generator\Commands\ActionGenerator;
+use Apiato\Core\Generator\Commands\CommandGenerator;
 use Apiato\Core\Generator\Commands\ConfigurationGenerator;
 use Apiato\Core\Generator\Commands\ContainerApiGenerator;
 use Apiato\Core\Generator\Commands\ContainerGenerator;
@@ -60,6 +61,7 @@ class GeneratorsServiceProvider extends ServiceProvider
         // all generators ordered by name
         $this->registerGenerators([
             ActionGenerator::class,
+            CommandGenerator::class,
             ConfigurationGenerator::class,
             ContainerGenerator::class,
             ContainerApiGenerator::class,

--- a/Generator/Stubs/command.stub
+++ b/Generator/Stubs/command.stub
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Containers\{{container-name}}\UI\CLI\Commands;
+
+use App\Ship\Parents\Commands\ConsoleCommand;
+
+/**
+ * Class {{class-name}}
+ */
+class {{class-name}} extends ConsoleCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:name';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //
+    }
+}
+


### PR DESCRIPTION
Generators are very helpful to easily create Jobs, Migrations, etc., but there is no generator for artisan commands.

This PR makes possible to easy create commands inside the file Porto SAP structure by running `php artisan apiato:generate:command`.