### PR TITLE
Fixed bug with pagination skip

### DIFF
--- a/Abstracts/Repositories/Repository.php
+++ b/Abstracts/Repositories/Repository.php
@@ -77,7 +77,7 @@ abstract class Repository extends PrettusRepository implements PrettusCacheable
     {
         // the priority is for the function parameter, if not available then take
         // it from the request if available and if not keep it null.
-        $limit = $limit ?: Request::get('limit');
+        $limit = isset($limit) ? $limit : Request::get('limit');
 
         // check, if skipping pagination is allowed and requested by the user
         if ($limit == "0" && Config::get('repository.pagination.skip')) {


### PR DESCRIPTION
### Issue
It doesn't return all entries while `$limit` is passed as `0` **(zero) integer**.

### Reproducing:
I've enabled `PAGINATION_SKIP` (true) in `ENV` file at first. Then executed the function:
`$this->repository->paginate(0);`

All I've **got the paginated list** of entries.

### Fix
✔️ Adding `isset($limit)` check fixed the issue.

### Test
✔️ Tested via query params by requests and directly in Tasks.

Let me know if there's more practical way.  