### PR TITLE
Added sorting function for solve nesting problem

### DIFF
--- a/Loaders/RoutesLoaderTrait.php
+++ b/Loaders/RoutesLoaderTrait.php
@@ -3,6 +3,7 @@
 namespace Apiato\Core\Loaders;
 
 use Apiato\Core\Foundation\Facades\Apiato;
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
@@ -22,6 +23,8 @@ trait RoutesLoaderTrait
             $this->loadApiContainerRoutes($containerPath);
             $this->loadWebContainerRoutes($containerPath);
         }
+
+        $this->sortRouting();
     }
 
     /**
@@ -189,5 +192,20 @@ trait RoutesLoaderTrait
         ], function ($router) use ($file) {
             require $file->getPathname();
         });
+    }
+
+    /**
+     * Sorting routes to avoid nesting problems
+     * @return void
+     */
+    private function sortRouting(): void
+    {
+        $routes = Route::getRoutes()->getRoutes();
+        usort($routes, fn($a, $b) => $a->uri <=> $b->uri);
+        $routeCollection = new RouteCollection();
+        foreach ($routes as $route) {
+            $routeCollection->add($route);
+        }
+        Route::setRoutes($routeCollection);
     }
 }


### PR DESCRIPTION
In the process of using Apiato I ran into such a problem.

If urls with inheritance are used in api, that is /stores/apples/..., due to the absence of sorts, the parameters are overwritten and the request goes to the wrong place.

Because /stores/{id} comes first then /stores/apples

In my working project, I did a similar function and it solved the problem.