### PR TITLE
Fix #147 container generator

### DIFF
--- a/Generator/Commands/ContainerApiGenerator.php
+++ b/Generator/Commands/ContainerApiGenerator.php
@@ -24,6 +24,7 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
         ['events', null, InputOption::VALUE_OPTIONAL, 'Generate Events for this Container?'],
         ['listeners', null, InputOption::VALUE_OPTIONAL, 'Generate Event Listeners for Events of this Container?'],
         ['tests', null, InputOption::VALUE_OPTIONAL, 'Generate Tests for this Container?'],
+        ['maincalled', false, InputOption::VALUE_NONE],
     ];
     /**
      * The console command name.
@@ -367,8 +368,7 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
             ]);
         }
 
-        $this->printInfoMessage('Generating Composer File');
-        return [
+       $generateComposerFile = [
             'path-parameters' => [
                 'section-name' => $this->sectionName,
                 'container-name' => $this->containerName,
@@ -384,6 +384,14 @@ class ContainerApiGenerator extends GeneratorCommand implements ComponentsGenera
                 'file-name' => $this->fileName,
             ],
         ];
+
+        if (!$this->option('maincalled')){
+            $this->printInfoMessage('Generating Composer File');
+            return $generateComposerFile;
+        }
+
+        return null;
+        
     }
 
     /**

--- a/Generator/Commands/ContainerGenerator.php
+++ b/Generator/Commands/ContainerGenerator.php
@@ -70,6 +70,7 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
                 '--section' => $sectionName,
                 '--container' => $containerName,
                 '--file' => 'composer',
+                '--maincalled' => true,
             ]);
         }
 
@@ -78,6 +79,7 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
                 '--section' => $sectionName,
                 '--container' => $containerName,
                 '--file' => 'composer',
+                '--maincalled' => true,G
             ]);
         }
 

--- a/Generator/Commands/ContainerGenerator.php
+++ b/Generator/Commands/ContainerGenerator.php
@@ -79,7 +79,7 @@ class ContainerGenerator extends GeneratorCommand implements ComponentsGenerator
                 '--section' => $sectionName,
                 '--container' => $containerName,
                 '--file' => 'composer',
-                '--maincalled' => true,G
+                '--maincalled' => true,
             ]);
         }
 

--- a/Generator/Commands/ContainerWebGenerator.php
+++ b/Generator/Commands/ContainerWebGenerator.php
@@ -17,6 +17,7 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
     public array $inputs = [
         ['url', null, InputOption::VALUE_OPTIONAL, 'The base URI of all endpoints (/stores, /cars, ...)'],
         ['controllertype', null, InputOption::VALUE_OPTIONAL, 'The controller type (SAC, MAC)'],
+        ['maincalled', false, InputOption::VALUE_NONE],
     ];
     /**
      * The console command name.
@@ -280,9 +281,8 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
             ]);
         }
 
-        $this->printInfoMessage('Generating Composer File');
 
-        return [
+        $generateComposerFile = [
             'path-parameters' => [
                 'section-name' => $this->sectionName,
                 'container-name' => $this->containerName,
@@ -298,6 +298,13 @@ class ContainerWebGenerator extends GeneratorCommand implements ComponentsGenera
                 'file-name' => $this->fileName,
             ],
         ];
+
+        if (!$this->option('maincalled')){
+            $this->printInfoMessage('Generating Composer File');
+            return $generateComposerFile;
+        }
+        
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fixed https://github.com/apiato/core/issues/147

I suggest this solution:

Added an optional parameter (VALUE_NONE) 'maincalled' to the commands for generating web and api containers.

This parameter will be called from the apiato:generate:container command