### PR TITLE
fix: return type for not decodable hashed ids

### DIFF
--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -66,7 +66,7 @@ trait HashIdTrait
      *
      * if the id is not decodable, null will be returned
      */
-    public function decode(?string $id): int|null
+    public function decode(?string $id): ?int
     {
         // check if passed as null, (could be an optional decodable variable)
         if (is_null($id) || strtolower($id) === 'null') {

--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -58,13 +58,15 @@ trait HashIdTrait
 
     /**
      * @param string|null $id
-     * @return int|string|null
+     * @return int|null
      *
-     * if the decoded id is bigger than PHP_INT_MAX, it will return a string
+     * if the decoded id is bigger than PHP_INT_MAX, the decoder will return a string
+     * we will cut that off from propagating, because such big numerical identifiers
+     * are not practically used
      *
      * if the id is not decodable, null will be returned
      */
-    public function decode(?string $id): int|string|null
+    public function decode(?string $id): int|null
     {
         // check if passed as null, (could be an optional decodable variable)
         if (is_null($id) || strtolower($id) === 'null') {
@@ -72,7 +74,11 @@ trait HashIdTrait
         }
 
         // do the decoding if the ID looks like a hashed one
-        return empty($this->decoder($id)) ? null : $this->decoder($id)[0];
+        if (!empty($this->decoder($id))) {
+            return is_string($this->decoder($id)[0]) ? null : $this->decoder($id)[0];
+        }
+
+        return null;
     }
 
     private function decoder($id): array

--- a/Traits/HashIdTrait.php
+++ b/Traits/HashIdTrait.php
@@ -56,15 +56,23 @@ trait HashIdTrait
         return $result;
     }
 
-    public function decode($id)
+    /**
+     * @param string|null $id
+     * @return int|string|null
+     *
+     * if the decoded id is bigger than PHP_INT_MAX, it will return a string
+     *
+     * if the id is not decodable, null will be returned
+     */
+    public function decode(?string $id): int|string|null
     {
         // check if passed as null, (could be an optional decodable variable)
-        if (is_null($id) || strtolower($id) == 'null') {
+        if (is_null($id) || strtolower($id) === 'null') {
             return $id;
         }
 
         // do the decoding if the ID looks like a hashed one
-        return empty($this->decoder($id)) ? [] : $this->decoder($id)[0];
+        return empty($this->decoder($id)) ? null : $this->decoder($id)[0];
     }
 
     private function decoder($id): array


### PR DESCRIPTION
If we do have an optional parameter, thats being dehashed, if the hash is not valid, the decode would produce an empty array instead of null.

I fixed the return and also added typing for the parameter and return types. If the decoded id is bigger than `PHP_INT_MAX`, the decoder will return a string.

This might break other peoples code that expect this to return an empty array. It should not break, if its just used in bool checks, because both `null` and `[]` are falsy.