### PR TITLE
feat: support multiple segment versioning & no version with prefix turned on

### DIFF
--- a/Loaders/RoutesLoaderTrait.php
+++ b/Loaders/RoutesLoaderTrait.php
@@ -135,9 +135,9 @@ trait RoutesLoaderTrait
     private function getRouteFileVersionFromFileName(SplFileInfo $file): string|bool
     {
         $fileNameWithoutExtension = $this->getRouteFileNameWithoutExtension($file);
-        
+
         $fileNameWithoutExtensionExploded = explode('.', $fileNameWithoutExtension);
-    
+
         end($fileNameWithoutExtensionExploded);
     
         $version = prev($fileNameWithoutExtensionExploded);

--- a/Loaders/RoutesLoaderTrait.php
+++ b/Loaders/RoutesLoaderTrait.php
@@ -135,13 +135,23 @@ trait RoutesLoaderTrait
     private function getRouteFileVersionFromFileName(SplFileInfo $file): string|bool
     {
         $fileNameWithoutExtension = $this->getRouteFileNameWithoutExtension($file);
-
+        
         $fileNameWithoutExtensionExploded = explode('.', $fileNameWithoutExtension);
-
+    
         end($fileNameWithoutExtensionExploded);
-
-        // get the array before the last one
-        return prev($fileNameWithoutExtensionExploded);
+    
+        $version = prev($fileNameWithoutExtensionExploded);
+    
+        if ($version === 'noversion') {
+            return false;
+        }
+    
+        // Replace underscore with period for decimal versioning
+        return str_replace(
+          Config::get('apiato.api.multiple_segment_version_file_seperator', '-'), 
+          Config::get('apiato.api.multiple_segment_version_route_seperator', '.'), 
+          $version
+        );
     }
 
     private function getRouteFileNameWithoutExtension(SplFileInfo $file): string


### PR DESCRIPTION
TODO:

- [ ] create and link PR to documentation repo
- [ ] create and link PR to apiato repo for configs. 

Here are what the updates to the [docs](https://apiato.io/docs/next/core-features/api-versioning) would be
---

- [Multi-Segment Versioning](#multi-segment-versioning)
- [Opting Out of Versioning](#opting-out-of-versioning)

### Multi-Segment Versioning {#multi-segment-versioning}

Apiato supports multi-segment versioning, where by default, the behavior emulates decimal versioning.

**Configurable Separators:**

By default, an dash (`-`) is used in filenames to represent the separator for the multi-segment versioning, which will be translated to a period (`.`) in the URL.

However, you can configure the separator used in filenames and its counterpart for the route by setting `multiple_segment_version_file_seperator` and `multiple_segment_version_route_seperator` in the `apiato` configuration.

**Create:**

For default decimal versioning, use an dash in place of the period in the version section of the filename.

Examples:

- `ForgotPassword.v1-0.private.php`
- `MakeOrder.v2-5.public.php`
- `GetCar.v1-1-0.public.php`

**Use:**

The version in the URL will be converted to use the separator defined in the `multiple_segment_version_route_seperator` configuration (default is period).

Examples:

- `http://api.apiato.test/v1.0/password/forgot`
- `http://api.apiato.test/v2.5/order/make`
- `http://api.apiato.test/v1.1.0/car`


### Opting Out of Versioning {#opting-out-of-versioning}

There are two primary ways to opt out of versioning in Apiato:

1. **Globally**: By setting `enable_version_prefix` to `false` in the `apiato` configuration, you can opt out of versioning for all routes. This ensures none of your routes will have version prefixes automatically applied from the file names. 

2. **For Specific Routes**: If you prefer to keep the `enable_version_prefix` setting active but need to exclude specific routes from being versioned, use the `noversion` keyword in the route file name.

**Create:**

For specific route exclusions, incorporate the `noversion` keyword into the filename:

Example:

- `GetOauthRequestToken.noversion.public.php`

**Use:**

The endpoint inside that route file will not have a version prefix in its URL, even if `enable_version_prefix` is set to `true`.

Example:

- `http://api.apiato.test/oauth/request_token`

