### PR TITLE
Adding helpers for asserting database query count

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,6 @@
     <exclude>
       <directory suffix=".php">./tests</directory>
       <directory suffix=".php">./vendor</directory>
-      <directory suffix=".php">./src/Traits/TestTraits</directory>
     </exclude>
   </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,7 @@
     <exclude>
       <directory suffix=".php">./tests</directory>
       <directory suffix=".php">./vendor</directory>
+      <directory suffix=".php">./src/Traits/TestTraits</directory>
     </exclude>
   </source>
 </phpunit>

--- a/src/Abstracts/Tests/PhpUnit/TestCase.php
+++ b/src/Abstracts/Tests/PhpUnit/TestCase.php
@@ -6,6 +6,7 @@ use Apiato\Core\Traits\HashIdTrait;
 use Apiato\Core\Traits\TestCaseTrait;
 use Apiato\Core\Traits\TestTraits\PhpUnit\TestAssertionHelperTrait;
 use Apiato\Core\Traits\TestTraits\PhpUnit\TestAuthHelperTrait;
+use Apiato\Core\Traits\TestTraits\PhpUnit\TestDatabaseProfilerTrait;
 use Apiato\Core\Traits\TestTraits\PhpUnit\TestRequestHelperTrait;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -20,6 +21,7 @@ abstract class TestCase extends LaravelTestCase
     use TestAssertionHelperTrait;
     use HashIdTrait;
     use LazilyRefreshDatabase;
+    use TestDatabaseProfilerTrait;
 
     /**
      * The base URL to use while testing the application.

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -48,7 +48,6 @@ trait TestDatabaseProfilerTrait
 
     /**
      * Assert the number of database queries.
-     * @param int $expectedCount
      */
     protected function assertDatabaseQueryCount(int $expectedCount): void
     {
@@ -58,8 +57,6 @@ trait TestDatabaseProfilerTrait
 
     /**
      * Wrapper to profile database queries.
-     * @param callable $callback
-     * @return mixed
      */
     protected function profileDatabaseQueries(callable $callback): mixed
     {
@@ -72,9 +69,6 @@ trait TestDatabaseProfilerTrait
 
     /**
      * Wrapper to profile database queries and assert the number of queries.
-     * @param int $expectedCount
-     * @param callable $callback
-     * @return mixed
      */
     protected function profileDatabaseQueryCount(int $expectedCount, callable $callback): mixed
     {

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -45,4 +45,14 @@ trait TestDatabaseProfilerTrait
 
         return $result;
     }
+
+    protected function profileDatabaseQueriesCount(int $expectedCount, callable $callback): mixed
+    {
+        return $this->profileDatabaseQueries(function () use ($expectedCount, $callback) {
+            $result = $callback();
+            $this->assertDatabaseQueriesCount($expectedCount);
+
+            return $result;
+        });
+    }
 }

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -41,7 +41,7 @@ trait TestDatabaseProfilerTrait
     /**
      * Dump and die the database queries.
      */
-    protected function ddDatabaseQueries(): void
+    protected function ddDatabaseQueries(): never
     {
         dd($this->getDatabaseQueries());
     }

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -50,7 +50,7 @@ trait TestDatabaseProfilerTrait
      * Assert the number of database queries.
      * @param int $expectedCount
      */
-    protected function assertDatabaseQueriesCount(int $expectedCount): void
+    protected function assertDatabaseQueryCount(int $expectedCount): void
     {
         $actualCount = count($this->getDatabaseQueries());
         $this->assertEquals($expectedCount, $actualCount, "Expected $expectedCount database queries, but got $actualCount.");
@@ -76,7 +76,7 @@ trait TestDatabaseProfilerTrait
      * @param callable $callback
      * @return mixed
      */
-    protected function profileDatabaseQueriesCount(int $expectedCount, callable $callback): mixed
+    protected function profileDatabaseQueryCount(int $expectedCount, callable $callback): mixed
     {
         return $this->profileDatabaseQueries(function () use ($expectedCount, $callback) {
             $result = $callback();

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -48,6 +48,7 @@ trait TestDatabaseProfilerTrait
 
     /**
      * Assert the number of database queries.
+     * @param int $expectedCount
      */
     protected function assertDatabaseQueriesCount(int $expectedCount): void
     {
@@ -57,6 +58,8 @@ trait TestDatabaseProfilerTrait
 
     /**
      * Wrapper to profile database queries.
+     * @param callable $callback
+     * @return mixed
      */
     protected function profileDatabaseQueries(callable $callback): mixed
     {
@@ -69,6 +72,9 @@ trait TestDatabaseProfilerTrait
 
     /**
      * Wrapper to profile database queries and assert the number of queries.
+     * @param int $expectedCount
+     * @param callable $callback
+     * @return mixed
      */
     protected function profileDatabaseQueriesCount(int $expectedCount, callable $callback): mixed
     {

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -4,21 +4,33 @@ namespace Apiato\Core\Traits\TestTraits\PhpUnit;
 
 trait TestDatabaseProfilerTrait
 {
+    /**
+     * Start profiling database queries.
+     */
     protected function startDatabaseProfiler(): void
     {
         $this->app->make('db')->enableQueryLog();
     }
 
+    /**
+     * Stop profiling database queries.
+     */
     protected function stopDatabaseProfiler(): void
     {
         $this->app->make('db')->disableQueryLog();
     }
 
+    /**
+     * Get the database queries.
+     */
     protected function getDatabaseQueries(): array
     {
         return $this->app->make('db')->getQueryLog();
     }
 
+    /**
+     * Dump the database queries.
+     */
     protected function dumpDatabaseQueries(): void
     {
         foreach ($this->getDatabaseQueries() as $query) {
@@ -26,17 +38,26 @@ trait TestDatabaseProfilerTrait
         }
     }
 
+    /**
+     * Dump and die the database queries.
+     */
     protected function ddDatabaseQueries(): void
     {
         dd($this->getDatabaseQueries());
     }
 
+    /**
+     * Assert the number of database queries.
+     */
     protected function assertDatabaseQueriesCount(int $expectedCount): void
     {
         $actualCount = count($this->getDatabaseQueries());
         $this->assertEquals($expectedCount, $actualCount, "Expected $expectedCount database queries, but got $actualCount.");
     }
 
+    /**
+     * Wrapper to profile database queries.
+     */
     protected function profileDatabaseQueries(callable $callback): mixed
     {
         $this->startDatabaseProfiler();
@@ -46,6 +67,9 @@ trait TestDatabaseProfilerTrait
         return $result;
     }
 
+    /**
+     * Wrapper to profile database queries and assert the number of queries.
+     */
     protected function profileDatabaseQueriesCount(int $expectedCount, callable $callback): mixed
     {
         return $this->profileDatabaseQueries(function () use ($expectedCount, $callback) {

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Apiato\Core\Traits\TestTraits\PhpUnit;
+
+trait TestDatabaseProfilerTrait
+{
+    public function startDatabaseProfiler(): void
+    {
+        $this->app->make('db')->enableQueryLog();
+    }
+
+    public function stopDatabaseProfiler(): void
+    {
+        $this->app->make('db')->disableQueryLog();
+    }
+
+    public function getDatabaseQueries(): array
+    {
+        return $this->app->make('db')->getQueryLog();
+    }
+
+    public function dumpDatabaseQueries(): void
+    {
+        foreach ($this->getDatabaseQueries() as $query) {
+            dump($query['query']);
+        }
+    }
+
+    public function ddDatabaseQueries(): void
+    {
+        dd($this->getDatabaseQueries());
+    }
+
+    public function assertDatabaseQueriesCount(int $expectedCount): void
+    {
+        $actualCount = count($this->getDatabaseQueries());
+        $this->assertEquals($expectedCount, $actualCount, "Expected $expectedCount database queries, but got $actualCount.");
+    }
+}

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -56,6 +56,24 @@ trait TestDatabaseProfilerTrait
     }
 
     /**
+     * Assert that the database queries contain the expected query.
+     */
+    protected function assertDatabaseQueriesContains(string $expectedQuery): void
+    {
+        $queries = $this->getDatabaseQueries();
+
+        $found = false;
+        foreach ($queries as $query) {
+            if (str_contains($query['query'], $expectedQuery)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, "Expected query '$expectedQuery' not found in database queries.");
+    }
+
+    /**
      * Wrapper to profile database queries.
      */
     protected function profileDatabaseQueries(callable $callback): mixed

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -36,4 +36,13 @@ trait TestDatabaseProfilerTrait
         $actualCount = count($this->getDatabaseQueries());
         $this->assertEquals($expectedCount, $actualCount, "Expected $expectedCount database queries, but got $actualCount.");
     }
+
+    protected function profileDatabaseQueries(callable $callback): mixed
+    {
+        $this->startDatabaseProfiler();
+        $result = $callback();
+        $this->stopDatabaseProfiler();
+
+        return $result;
+    }
 }

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -7,7 +7,7 @@ trait TestDatabaseProfilerTrait
     /**
      * Start profiling database queries.
      */
-    protected function startDatabaseProfiler(): void
+    protected function startDatabaseQueryLog(): void
     {
         $this->app->make('db')->enableQueryLog();
     }
@@ -15,7 +15,7 @@ trait TestDatabaseProfilerTrait
     /**
      * Stop profiling database queries.
      */
-    protected function stopDatabaseProfiler(): void
+    protected function stopDatabaseQueryLog(): void
     {
         $this->app->make('db')->disableQueryLog();
     }
@@ -58,7 +58,7 @@ trait TestDatabaseProfilerTrait
     /**
      * Assert that the database queries contain the expected query.
      */
-    protected function assertDatabaseQueriesContains(string $expectedQuery): void
+    protected function assertDatabaseExecutedQuery(string $expectedQuery): void
     {
         $queries = $this->getDatabaseQueries();
 
@@ -71,6 +71,16 @@ trait TestDatabaseProfilerTrait
         }
 
         $this->assertTrue($found, "Expected query '$expectedQuery' not found in database queries.");
+    }
+
+    /**
+     * Assert that the database queries contain the expected queries.
+     */
+    protected function assertDatabaseExecutedQueries(array $expectedQueries): void
+    {
+        foreach ($expectedQueries as $expectedQuery) {
+            $this->assertDatabaseExecutedQuery($expectedQuery);
+        }
     }
 
     /**
@@ -93,6 +103,19 @@ trait TestDatabaseProfilerTrait
         return $this->profileDatabaseQueries(function () use ($expectedCount, $callback) {
             $result = $callback();
             $this->assertDatabaseQueriesCount($expectedCount);
+
+            return $result;
+        });
+    }
+
+    /**
+     * Wrapper to profile database queries and assert the executed query.
+     */
+    protected function profileDatabaseExecutedQuery(string $expectedQuery, callable $callback): mixed
+    {
+        return $this->profileDatabaseQueries(function () use ($expectedQuery, $callback) {
+            $result = $callback();
+            $this->assertDatabaseExecutedQuery($expectedQuery);
 
             return $result;
         });

--- a/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
+++ b/src/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTrait.php
@@ -4,34 +4,34 @@ namespace Apiato\Core\Traits\TestTraits\PhpUnit;
 
 trait TestDatabaseProfilerTrait
 {
-    public function startDatabaseProfiler(): void
+    protected function startDatabaseProfiler(): void
     {
         $this->app->make('db')->enableQueryLog();
     }
 
-    public function stopDatabaseProfiler(): void
+    protected function stopDatabaseProfiler(): void
     {
         $this->app->make('db')->disableQueryLog();
     }
 
-    public function getDatabaseQueries(): array
+    protected function getDatabaseQueries(): array
     {
         return $this->app->make('db')->getQueryLog();
     }
 
-    public function dumpDatabaseQueries(): void
+    protected function dumpDatabaseQueries(): void
     {
         foreach ($this->getDatabaseQueries() as $query) {
             dump($query['query']);
         }
     }
 
-    public function ddDatabaseQueries(): void
+    protected function ddDatabaseQueries(): void
     {
         dd($this->getDatabaseQueries());
     }
 
-    public function assertDatabaseQueriesCount(int $expectedCount): void
+    protected function assertDatabaseQueriesCount(int $expectedCount): void
     {
         $actualCount = count($this->getDatabaseQueries());
         $this->assertEquals($expectedCount, $actualCount, "Expected $expectedCount database queries, but got $actualCount.");

--- a/tests/Unit/Abstracts/Tests/PhpUnit/TestCaseTest.php
+++ b/tests/Unit/Abstracts/Tests/PhpUnit/TestCaseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Apiato\Core\Tests\Unit\Abstracts\Tests\PhpUnit;
+
+use Apiato\Core\Abstracts\Tests\PhpUnit\TestCase;
+use Apiato\Core\Tests\Unit\UnitTestCase;
+use Apiato\Core\Traits\HashIdTrait;
+use Apiato\Core\Traits\TestCaseTrait;
+use Apiato\Core\Traits\TestTraits\PhpUnit\TestAssertionHelperTrait;
+use Apiato\Core\Traits\TestTraits\PhpUnit\TestAuthHelperTrait;
+use Apiato\Core\Traits\TestTraits\PhpUnit\TestDatabaseProfilerTrait;
+use Apiato\Core\Traits\TestTraits\PhpUnit\TestRequestHelperTrait;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TestCase::class)]
+final class TestCaseTest extends UnitTestCase
+{
+    public function testUsesTraits(): void
+    {
+        $traits = [
+            TestCaseTrait::class,
+            TestAuthHelperTrait::class,
+            TestRequestHelperTrait::class,
+            TestAssertionHelperTrait::class,
+            HashIdTrait::class,
+            LazilyRefreshDatabase::class,
+            TestDatabaseProfilerTrait::class,
+        ];
+
+        foreach ($traits as $trait) {
+            $this->assertContains($trait, class_uses_recursive(TestCase::class));
+        }
+    }
+}

--- a/tests/Unit/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTraitTest.php
+++ b/tests/Unit/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Apiato\Core\Tests\Unit\Traits\TestTraits\PhpUnit;
+
+use Apiato\Core\Tests\Unit\UnitTestCase;
+use Apiato\Core\Traits\TestTraits\PhpUnit\TestDatabaseProfilerTrait;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TestDatabaseProfilerTrait::class)]
+class TestDatabaseProfilerTraitTest extends UnitTestCase
+{
+    use TestDatabaseProfilerTrait;
+
+    public function testStartDatabaseQueryLog(): void
+    {
+        DB::expects()->enableQueryLog();
+
+        $this->startDatabaseQueryLog();
+    }
+
+    public function testStopDatabaseQueryLog(): void
+    {
+        DB::expects()->disableQueryLog();
+
+        $this->stopDatabaseQueryLog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->trait = new class {
+            use TestDatabaseProfilerTrait;
+        };
+    }
+
+    public function testGetDatabaseQueries(): void
+    {
+        $this->markTestIncomplete('To be implemented');
+    }
+}

--- a/tests/Unit/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTraitTest.php
+++ b/tests/Unit/Traits/TestTraits/PhpUnit/TestDatabaseProfilerTraitTest.php
@@ -26,16 +26,450 @@ class TestDatabaseProfilerTraitTest extends UnitTestCase
         $this->stopDatabaseQueryLog();
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->trait = new class {
-            use TestDatabaseProfilerTrait;
-        };
-    }
-
     public function testGetDatabaseQueries(): void
     {
-        $this->markTestIncomplete('To be implemented');
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertEquals($queries, $this->getDatabaseQueries());
+    }
+
+    public function testAssertDatabaseQueryCount(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseQueryCount(2);
+    }
+
+    public function testAssertDatabaseQueryCountWithDifferentCount(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage('Expected 3 database queries, but got 2.');
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseQueryCount(3);
+    }
+
+    public function testAssertDatabaseQueryCountWithEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseQueryCount(0);
+    }
+
+    public function testAssertDatabaseExecutedQuery(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseExecutedQuery('query1');
+    }
+
+    public function testAssertDatabaseExecutedQueryWithDifferentQuery(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query3' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQuery('query3');
+    }
+
+    public function testAssertDatabaseExecutedQueryWithEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQuery('query1');
+    }
+
+    public function testAssertDatabaseExecutedQueryWithEmptyQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query '' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQuery('');
+    }
+
+    public function testAssertDatabaseExecutedQueryWithDifferentQueriesAndEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQuery('query1');
+    }
+
+    public function testAssertDatabaseExecutedQueryWithEmptyQueriesAndDatabaseQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseExecutedQuery('');
+    }
+
+    public function testAssertDatabaseExecutedQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2'], ['query' => 'query3']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseExecutedQueries(['query1', 'query2']);
+    }
+
+    public function testAssertDatabaseExecutedQueriesWithDifferentQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query3' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQueries(['query1', 'query3']);
+    }
+
+    public function testAssertDatabaseExecutedQueriesWithDifferentQueries2(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query4' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQueries(['query4', 'query3']);
+    }
+
+    public function testAssertDatabaseExecutedQueriesWithEmptyQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseExecutedQueries([]);
+    }
+
+    public function testAssertDatabaseExecutedQueriesWithEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQueries(['query1']);
+    }
+
+    public function testAssertDatabaseExecutedQueriesWithEmptyQueriesAndDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->assertDatabaseExecutedQueries([]);
+    }
+
+    public function testAssertDatabaseExecutedQueriesWithDifferentQueriesAndEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->assertDatabaseExecutedQueries(['query1']);
+    }
+
+    public function testProfileDatabaseQueries(): void
+    {
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+
+        $this->profileDatabaseQueries(function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseQueriesRunsClosure(): void
+    {
+        $closureRan = false;
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+
+        $this->profileDatabaseQueries(function () use (&$closureRan) {
+            $closureRan = true;
+        });
+
+        $this->assertTrue($closureRan);
+    }
+
+    public function testProfileDatabaseQueriesWithException(): void
+    {
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+
+        $this->expectException(\Exception::class);
+        $this->profileDatabaseQueries(function () {
+            throw new \Exception();
+        });
+    }
+
+    public function testProfileDatabaseQueryCount(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseQueryCount(2, function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseQueryCountWithDifferentCount(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage('Expected 3 database queries, but got 2.');
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseQueryCount(3, function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseQueryCountRunsClosure(): void
+    {
+        $closureRan = false;
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn([]);
+
+        $this->profileDatabaseQueryCount(0, function () use (&$closureRan) {
+            $closureRan = true;
+        });
+
+        $this->assertTrue($closureRan);
+    }
+
+    public function testProfileDatabaseQueryCountWithException(): void
+    {
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+
+        $this->expectException(\Exception::class);
+        $this->profileDatabaseQueryCount(0, function () {
+            throw new \Exception();
+        });
+    }
+
+    public function testProfileDatabaseExecutedQuery(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQuery('query1', function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueryWithDifferentQuery(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query3' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseExecutedQuery('query3', function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueryWithEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseExecutedQuery('query1', function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueryWithEmptyQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQuery('', function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueryWithDifferentQueriesAndEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseExecutedQuery('query1', function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueryWithEmptyQueriesAndDatabaseQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQuery('', function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueryRunsClosure(): void
+    {
+        $closureRan = false;
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQuery('query1', function () use (&$closureRan) {
+            $closureRan = true;
+        });
+
+        $this->assertTrue($closureRan);
+    }
+
+    public function testProfileDatabaseExecutedQueryWithException(): void
+    {
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+
+        $this->expectException(\Exception::class);
+        $this->profileDatabaseExecutedQuery('query1', function () {
+            throw new \Exception();
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQueries(['query1', 'query2'], function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueriesWithDifferentQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query3' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseExecutedQueries(['query1', 'query3'], function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueriesWithDifferentQueries2(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query4' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseExecutedQueries(['query4', 'query3'], function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueriesWithEmptyQueries(): void
+    {
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQueries([], function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueriesWithEmptyDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->expectExceptionMessage("Expected query 'query1' not found in database queries.");
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->profileDatabaseExecutedQueries(['query1'], function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueriesWithEmptyQueriesAndDatabaseQueries(): void
+    {
+        $queries = [];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQueries([], function () {
+            // Do nothing
+        });
+    }
+
+    public function testProfileDatabaseExecutedQueriesRunsClosure(): void
+    {
+        $closureRan = false;
+        $queries = [['query' => 'query1'], ['query' => 'query2']];
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+        DB::expects()->getQueryLog()->andReturn($queries);
+
+        $this->profileDatabaseExecutedQueries(['query1'], function () use (&$closureRan) {
+            $closureRan = true;
+        });
+
+        $this->assertTrue($closureRan);
+    }
+
+    public function testProfileDatabaseExecutedQueriesWithException(): void
+    {
+        DB::expects()->enableQueryLog();
+        DB::expects()->disableQueryLog();
+
+        $this->expectException(\Exception::class);
+        $this->profileDatabaseExecutedQueries(['query1'], function () {
+            throw new \Exception();
+        });
     }
 }


### PR DESCRIPTION
## Description
[//]: # (Please include a summary of the change and which issue is fixed.  )
[//]: # (Please also include relevant motivation and context.  )
[//]: # (List any dependencies that are required for this change.)
Dealing with performance and scaling issues due to poorly designed code logic can cause a lot of hard to pin problems, especially in bigger projects. This PR adds some helpers to give the tools during development and in tests to check for hidden N+1 problems.

[This PR](https://github.com/apiato/documentation/pull/106) adds the documentation for the functionality.

## Type of change
[//]: # (Please put an x in the box that apply.)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (refactoring a current feature, method, etc...)
- [ ] Code Coverage (adding/removing/updating/refactoring tests)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Remove feature (non-breaking change which removes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

